### PR TITLE
Change FFMS_ID from H265 to HEVC to be consistent.

### DIFF
--- a/src/core/codectype.cpp
+++ b/src/core/codectype.cpp
@@ -81,8 +81,8 @@ static const CodecTags mkv_codec_tags[] = {
 	{"V_MPEG4/ISO/SP"      , FFMS_ID(MPEG4)},
 	{"V_MPEG4/ISO/AVC"     , FFMS_ID(H264)},
 	{"V_MPEG4/MS/V3"       , FFMS_ID(MSMPEG4V3)},
-#if VERSION_CHECK(LIBAVFORMAT_VERSION_INT, >=, 255, 255, 255, 55, 15, 100)
-	{"V_MPEGH/ISO/HEVC"    , FFMS_ID(H265)},
+#if VERSION_CHECK(LIBAVFORMAT_VERSION_INT, >=, 255, 255, 255, 55, 38, 101)
+	{"V_MPEGH/ISO/HEVC"    , FFMS_ID(HEVC)},
 #endif
 	{"V_REAL/RV10"         , FFMS_ID(RV10)},
 	{"V_REAL/RV20"         , FFMS_ID(RV20)},


### PR DESCRIPTION
There is no confusion over whether there'll be a split between
MPEG and ITU-T names, since FFmpeg moved to using 'HEVC' also.
