### PR TITLE
ffmsindex: do not report an error when no options are supplied

### DIFF
--- a/src/index/ffmsindex.cpp
+++ b/src/index/ffmsindex.cpp
@@ -81,11 +81,6 @@ void PrintUsage() {
 }
 
 void ParseCMDLine(int argc, char *argv[]) {
-	if (argc <= 1) {
-		PrintUsage();
-		throw Error("");
-	}
-
 	for (int i = 1; i < argc; ++i) {
 		const char *Option = argv[i];
 #define OPTION_ARG(flag) i + 1 < argc ? argv[i+1] : throw Error("Error: missing argument for -" flag)
@@ -288,6 +283,11 @@ int wmain(int argc, wchar_t *_argv[]) {
 int main(int argc, char *argv[]) {
 #endif /* defined(_WIN32) && !defined(__MINGW32__) */
 	try {
+		if (argc <= 1) {
+			PrintUsage();
+			return 0;
+		}
+
 		ParseCMDLine(argc, argv);
 	}
 	catch (Error const& e) {


### PR DESCRIPTION
Hi, I am writing a homebrew formula for ffms2.
Among the optional requirements there is a test section used to guarantee that the program compiled; documentation suggests that just running one of the program with version or help text is enough.
However ffms2 does not come with those and even when called without parameters it returns an error state.

This patch changes that behaviour, so that running 'ffmsindex' will return 0.
If you prefer I could add a -h option instead.
