### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# But don't mess up Unix scripts in the process
+*.sh    eol=lf
+*.in    eol=lf
+*.am    eol=lf
+*.ac    eol=lf
+*.m4    eol=lf
+# Scripts that don't have extensions...
+/install-sh     eol=lf
+/compile        eol=lf
+/configure      eol=lf
+/config.guess   eol=lf
+/config.sub     eol=lf
+/depcomp        eol=lf
+/install-sh     eol=lf
+/missing        eol=lf


### PR DESCRIPTION
This attempts to make things slightly cleaner when checking out from Git via Windows by telling Git to properly deal with line endings explicitly (which is probably useless on most Windows installs as core.autocrlf is probably set globally) but also by explicitly setting the line endings on the UNIX scripts so that attempting to run them through something like Cygwin will still work. (As by default these days Cygwin doesn't mount Windows file systems in "text mode.")