### PR TITLE
ffmsindex: Do not leak the Index object on exit

### DIFF
--- a/src/index/ffmsindex.cpp
+++ b/src/index/ffmsindex.cpp
@@ -60,6 +60,10 @@ struct Error {
 	}
 };
 
+void CleanUp() {
+	FFMS_DestroyIndex(Index);
+}
+
 void PrintUsage() {
 	std::cout <<
 		"FFmpegSource2 indexing app\n"
@@ -289,6 +293,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	try {
+		atexit(CleanUp);
 		DoIndexing();
 	}
 	catch (Error const& e) {


### PR DESCRIPTION
This reproducible with valgrind

==68209== 687,700 (72 direct, 687,628 indirect) bytes in 1 blocks are definitely lost in loss record 856 of 858
==68209==    by 0x20ED28D: operator new(unsigned long) (in /usr/lib/libc++.1.dylib)
==68209==    by 0x1000155D3: FFMS_ReadIndex (ffms.cpp:406)
==68209==    by 0x10000215F: (anonymous namespace)::DoIndexing() (ffmsindex.cpp:173)
==68209==    by 0x10000150E: main (ffmsindex.cpp:297)