### PR TITLE
Include frame file position in FFMS_FrameInfo

### DIFF
--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -1159,6 +1159,7 @@ typedef struct {
     int64_t PTS;
     int RepeatPict;
     int KeyFrame;
+    int64_t FilePos;
 } FFMS_FrameInfo;
 ```
 A struct representing basic metadata about a given video frame.
@@ -1167,6 +1168,7 @@ The fields are:
    To convert this to a timestamp in wallclock milliseconds, use the relation `int64_t timestamp = (int64_t)((FFMS_FrameInfo->PTS * FFMS_TrackTimeBase->Num) / (double)FFMS_TrackTimeBase->Den)`.
  - `int RepeatPict` - RFF flag for the frame; same as in `FFMS_Frame`, see that structure for an explanation.
  - `int KeyFrame` - Non-zero if the frame is a keyframe, zero otherwise.
+ - `int64_t FilePos` - Position of the frame within the file in bytes.
 
 ### FFMS_VideoProperties
 

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -363,6 +363,7 @@ typedef struct FFMS_FrameInfo {
 	int64_t PTS;
 	int RepeatPict;
 	int KeyFrame;
+	int64_t FilePos;
 } FFMS_FrameInfo;
 
 typedef struct FFMS_VideoProperties {

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -413,6 +413,7 @@ FFMS_API(const FFMS_VideoProperties *) FFMS_GetVideoProperties(FFMS_VideoSource 
 FFMS_API(const FFMS_AudioProperties *) FFMS_GetAudioProperties(FFMS_AudioSource *A);
 FFMS_API(const FFMS_Frame *) FFMS_GetFrame(FFMS_VideoSource *V, int n, FFMS_ErrorInfo *ErrorInfo);
 FFMS_API(const FFMS_Frame *) FFMS_GetFrameByTime(FFMS_VideoSource *V, double Time, FFMS_ErrorInfo *ErrorInfo);
+FFMS_API(const FFMS_Frame *) FFMS_GetFrameByPosition(FFMS_VideoSource *V, int64_t Position, FFMS_ErrorInfo *ErrorInfo);
 FFMS_API(int) FFMS_GetAudio(FFMS_AudioSource *A, void *Buf, int64_t Start, int64_t Count, FFMS_ErrorInfo *ErrorInfo);
 FFMS_API(int) FFMS_SetOutputFormatV2(FFMS_VideoSource *V, const int *TargetFormats, int Width, int Height, int Resizer, FFMS_ErrorInfo *ErrorInfo); /* Introduced in FFMS_VERSION ((2 << 24) | (15 << 16) | (3 << 8) | 0) */
 FFMS_API(void) FFMS_ResetOutputFormatV(FFMS_VideoSource *V);

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -364,6 +364,7 @@ typedef struct FFMS_FrameInfo {
 	int RepeatPict;
 	int KeyFrame;
 	int64_t FilePos;
+	int Frame;
 } FFMS_FrameInfo;
 
 typedef struct FFMS_VideoProperties {
@@ -436,6 +437,8 @@ FFMS_API(const char *) FFMS_GetCodecNameI(FFMS_Indexer *Indexer, int Track);
 FFMS_API(const char *) FFMS_GetFormatNameI(FFMS_Indexer *Indexer);
 FFMS_API(int) FFMS_GetNumFrames(FFMS_Track *T);
 FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfo(FFMS_Track *T, int Frame);
+FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfoFromPTS(FFMS_Track *T, int64_t PTS);
+FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfoFromPos(FFMS_Track *T, int64_t POS);
 FFMS_API(FFMS_Track *) FFMS_GetTrackFromIndex(FFMS_Index *Index, int Track);
 FFMS_API(FFMS_Track *) FFMS_GetTrackFromVideo(FFMS_VideoSource *V);
 FFMS_API(FFMS_Track *) FFMS_GetTrackFromAudio(FFMS_AudioSource *A);

--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -311,6 +311,14 @@ FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfo(FFMS_Track *T, int Frame) {
 	return T->GetFrameInfo(static_cast<size_t>(Frame));
 }
 
+FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfoFromPTS(FFMS_Track *T, int64_t PTS) {
+	return T->GetFrameInfo(T->FrameFromPTS(PTS));
+}
+
+FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfoFromPos(FFMS_Track *T, int64_t Pos) {
+	return T->GetFrameInfo(T->FrameFromPos(Pos));
+}
+
 FFMS_API(FFMS_Track *) FFMS_GetTrackFromIndex(FFMS_Index *Index, int Track) {
 	return &(*Index)[Track];
 }

--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -174,6 +174,17 @@ FFMS_API(const FFMS_Frame *) FFMS_GetFrameByTime(FFMS_VideoSource *V, double Tim
 	}
 }
 
+FFMS_API(const FFMS_Frame *) FFMS_GetFrameByPosition(FFMS_VideoSource *V, int64_t Position, FFMS_ErrorInfo *ErrorInfo) {
+	ClearErrorInfo(ErrorInfo);
+	try {
+		return V->GetFrameByPosition(Position);
+	}
+	catch (FFMS_Exception &e) {
+		e.CopyOut(ErrorInfo);
+		return nullptr;
+	}
+}
+
 FFMS_API(int) FFMS_GetAudio(FFMS_AudioSource *A, void *Buf, int64_t Start, int64_t Count, FFMS_ErrorInfo *ErrorInfo) {
 	ClearErrorInfo(ErrorInfo);
 	try {

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -262,7 +262,7 @@ void FFMS_Track::GeneratePublicInfo() {
             continue;
         RealFrameNumbers.push_back(static_cast<int>(i));
 
-		FFMS_FrameInfo info = {Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].FilePos};
+		FFMS_FrameInfo info = {Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].FilePos, i};
 		PublicFrameInfo.push_back(info);
 	}
 }

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -262,7 +262,7 @@ void FFMS_Track::GeneratePublicInfo() {
             continue;
         RealFrameNumbers.push_back(static_cast<int>(i));
 
-		FFMS_FrameInfo info = {Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame};
+		FFMS_FrameInfo info = { Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].FilePos };
 		PublicFrameInfo.push_back(info);
 	}
 }

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -262,7 +262,7 @@ void FFMS_Track::GeneratePublicInfo() {
             continue;
         RealFrameNumbers.push_back(static_cast<int>(i));
 
-		FFMS_FrameInfo info = { Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].FilePos };
+		FFMS_FrameInfo info = {Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].FilePos};
 		PublicFrameInfo.push_back(info);
 	}
 }

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -178,6 +178,11 @@ FFMS_Frame *FFMS_VideoSource::GetFrameByTime(double Time) {
 	return GetFrame(Frame);
 }
 
+FFMS_Frame *FFMS_VideoSource::GetFrameByPosition(int64_t Position) {
+	int Frame = Frames.FrameFromPos(Position);
+	return GetFrame(Frame);
+}
+
 static AVColorRange handle_jpeg(PixelFormat *format) {
 	switch (*format) {
 		case PIX_FMT_YUVJ420P: *format = PIX_FMT_YUV420P; return AVCOL_RANGE_JPEG;

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -89,6 +89,7 @@ public:
 	virtual FFMS_Frame *GetFrame(int n) = 0;
 	void GetFrameCheck(int n);
 	FFMS_Frame *GetFrameByTime(double Time);
+	FFMS_Frame *GetFrameByPosition(int64_t Position);
 	void SetOutputFormat(const PixelFormat *TargetFormats, int Width, int Height, int Resizer);
 	void ResetOutputFormat();
 	void SetInputFormat(int ColorSpace, int ColorRange, PixelFormat Format);


### PR DESCRIPTION
Not sure what kind of procedure there is for modifying the public API, but I wanted to throw this out there as I need it for a project I'm working on.

Here's the reasoning behind this addition:
Sometimes frames do not contain PTS information (and players like ffplay reset their frame number on seeking), and therefore the only way to truly know "where you are" reliably during playback is based on file position. For instance, the show info filter in ffplay/ffmpeg includes the position of the frame being displayed. Using that information we can easily relate back to our index built with ffms2.

Any thoughts or discussion on this? Is this something suitable for inclusion in the project?