### PR TITLE
SWResample Support / Visual Studio compiled libraries

### DIFF
--- a/include/ffmscompat.h
+++ b/include/ffmscompat.h
@@ -98,4 +98,29 @@ static const AVPixFmtDescriptor *av_pix_fmt_desc_get(AVPixelFormat pix_fmt) {
 #	endif
 #endif
 
+
+#ifdef WITH_AVRESAMPLE
+#define FFMS_RESAMPLING_ENABLED
+#define ffms_convert(AVAudioResampleContext, output, out_plane_size, byte_per_sample_src, out_samples, input, in_plane_size, byte_per_sample_target, in_samples)	\
+		avresample_convert(AVAudioResampleContext, output, out_plane_size*byte_per_sample_src, out_samples, input, in_plane_size*byte_per_sample_target, in_samples)	
+#define ffms_open(context)			avresample_open(context)
+#define FFMS_ResampleContext		AVAudioResampleContext
+#define ffms_resample_alloc_context	avresample_alloc_context
+#define ffms_resample_free			avresample_free
+#endif
+
+#ifdef	WITH_SWRESAMPLE
+#define FFMS_RESAMPLING_ENABLED
+#define ffms_convert(AVAudioResampleContext, output, out_plane_size, byte_per_sample_src, out_samples, input, in_plane_size, bps, in_samples)	\
+		swr_convert(AVAudioResampleContext, output, out_samples, (const uint8_t**) input, in_samples)	
+#define ffms_open(context)			swr_init(context)
+#define FFMS_ResampleContext		SwrContext	
+#define ffms_resample_alloc_context	swr_alloc
+#define ffms_resample_free			swr_free
+#endif
+
+#if defined(WITH_AVRESAMPLE) && defined(WITH_SWRESAMPLE)
+#	error "Trying to compile library with AVResample and SwResample at the same time. This is not possible."
+#endif
+
 #endif // FFMSCOMPAT_H

--- a/include/ffmscompat.h
+++ b/include/ffmscompat.h
@@ -98,29 +98,4 @@ static const AVPixFmtDescriptor *av_pix_fmt_desc_get(AVPixelFormat pix_fmt) {
 #	endif
 #endif
 
-
-#ifdef WITH_AVRESAMPLE
-#define FFMS_RESAMPLING_ENABLED
-#define ffms_convert(AVAudioResampleContext, output, out_plane_size, byte_per_sample_src, out_samples, input, in_plane_size, byte_per_sample_target, in_samples)	\
-		avresample_convert(AVAudioResampleContext, output, out_plane_size*byte_per_sample_src, out_samples, input, in_plane_size*byte_per_sample_target, in_samples)	
-#define ffms_open(context)			avresample_open(context)
-#define FFMS_ResampleContext		AVAudioResampleContext
-#define ffms_resample_alloc_context	avresample_alloc_context
-#define ffms_resample_free			avresample_free
-#endif
-
-#ifdef	WITH_SWRESAMPLE
-#define FFMS_RESAMPLING_ENABLED
-#define ffms_convert(AVAudioResampleContext, output, out_plane_size, byte_per_sample_src, out_samples, input, in_plane_size, bps, in_samples)	\
-		swr_convert(AVAudioResampleContext, output, out_samples, (const uint8_t**) input, in_samples)	
-#define ffms_open(context)			swr_init(context)
-#define FFMS_ResampleContext		SwrContext	
-#define ffms_resample_alloc_context	swr_alloc
-#define ffms_resample_free			swr_free
-#endif
-
-#if defined(WITH_AVRESAMPLE) && defined(WITH_SWRESAMPLE)
-#	error "Trying to compile library with AVResample and SwResample at the same time. This is not possible."
-#endif
-
 #endif // FFMSCOMPAT_H

--- a/src/config/libs.cpp
+++ b/src/config/libs.cpp
@@ -40,7 +40,8 @@ extern "C" {
 #pragma comment(lib, "zlib.lib")
 #endif /* WITH_GCC_LIBAV */
 
-// libav/ffmpeg libs are the same (name) regardless of their compiler.
+#ifdef WITH_GCC_LIBAV
+// libav/ffmpeg libs are the same (name) for GCC compiled binaries
 #pragma comment(lib, "libavutil.a")
 #pragma comment(lib, "libavcodec.a")
 #pragma comment(lib, "libavformat.a")
@@ -50,6 +51,19 @@ extern "C" {
 #endif
 #ifdef WITH_SWRESAMPLE
 #pragma comment(lib, "libswresample.a")
+#endif
+#else
+// libav/ffmpeg libs are the same (name) for Visual Studio compiled binaries (no matter static or shared)
+#pragma comment(lib, "avutil.lib")
+#pragma comment(lib, "avcodec.lib")
+#pragma comment(lib, "avformat.lib")
+#pragma comment(lib, "swscale.lib")
+#ifdef WITH_AVRESAMPLE
+#pragma comment(lib, "avresample.lib")
+#endif
+#ifdef WITH_SWRESAMPLE
+#pragma comment(lib, "swresample.lib")
+#endif
 #endif
 
 #ifdef WITH_OPENCORE_AMR_NB

--- a/src/config/libs.cpp
+++ b/src/config/libs.cpp
@@ -40,8 +40,7 @@ extern "C" {
 #pragma comment(lib, "zlib.lib")
 #endif /* WITH_GCC_LIBAV */
 
-#ifdef WITH_GCC_LIBAV
-// libav/ffmpeg libs are the same (name) for GCC compiled binaries
+// libav/ffmpeg libs are the same (name) regardless of their compiler.
 #pragma comment(lib, "libavutil.a")
 #pragma comment(lib, "libavcodec.a")
 #pragma comment(lib, "libavformat.a")
@@ -51,19 +50,6 @@ extern "C" {
 #endif
 #ifdef WITH_SWRESAMPLE
 #pragma comment(lib, "libswresample.a")
-#endif
-#else
-// libav/ffmpeg libs are the same (name) for Visual Studio compiled binaries (no matter static or shared)
-#pragma comment(lib, "avutil.lib")
-#pragma comment(lib, "avcodec.lib")
-#pragma comment(lib, "avformat.lib")
-#pragma comment(lib, "swscale.lib")
-#ifdef WITH_AVRESAMPLE
-#pragma comment(lib, "avresample.lib")
-#endif
-#ifdef WITH_SWRESAMPLE
-#pragma comment(lib, "swresample.lib")
-#endif
 #endif
 
 #ifdef WITH_OPENCORE_AMR_NB

--- a/src/core/audiosource.cpp
+++ b/src/core/audiosource.cpp
@@ -182,7 +182,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"Sample rate changes are currently unsupported.");
 
-#ifndef WITH_AVRESAMPLE
+#if !defined(WITH_AVRESAMPLE) && !defined(WITH_SWRESAMPLE)
 	if (opt.SampleFormat != AP.SampleFormat || opt.SampleRate != AP.SampleRate || opt.ChannelLayout != AP.ChannelLayout)
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"FFMS was not built with resampling enabled. The only supported conversion is interleaving planar audio.");
@@ -215,10 +215,29 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 			"Could not open avresample context");
 	newContext.swap(ResampleContext);
 #endif
+#ifdef WITH_SWRESAMPLE
+	if (!NeedsResample) return;
+
+	FFResampleContext newContext;
+	SetOptions(opt, newContext, resample_options);
+	av_opt_set_int(newContext, "in_sample_rate", AP.SampleRate, 0);
+	av_opt_set_int(newContext, "in_sample_fmt", CodecContext->sample_fmt, 0);
+	av_opt_set_int(newContext, "in_channel_layout", AP.ChannelLayout, 0);
+
+	av_opt_set_channel_layout(newContext, "out_channel_layout", opt.ChannelLayout, 0);
+	av_opt_set_int(newContext, "out_sample_rate", opt.SampleRate, 0);
+	av_opt_set_sample_fmt(newContext, "out_sample_fmt", (AVSampleFormat)opt.SampleFormat, 0);
+
+
+	if (swr_init(newContext))
+		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNKNOWN,
+			"Could not open avresample context");
+	newContext.swap(ResampleContext);
+#endif
 }
 
 std::unique_ptr<FFMS_ResampleOptions> FFMS_AudioSource::CreateResampleOptions() const {
-#ifdef WITH_AVRESAMPLE
+#if defined(WITH_AVRESAMPLE) || defined(WITH_SWRESAMPLE)
 	auto ret = ReadOptions(ResampleContext, resample_options);
 #else
 	auto ret = make_unique<FFMS_ResampleOptions>();
@@ -244,6 +263,14 @@ void FFMS_AudioSource::ResampleAndCache(CacheIterator pos) {
 		OutPlanes, new_req, DecodeFrame->nb_samples,
 		DecodeFrame->extended_data, DecodeFrame->nb_samples * av_get_bytes_per_sample(CodecContext->sample_fmt), DecodeFrame->nb_samples);
 #else
+#if defined(WITH_SWRESAMPLE)
+	block.Data.resize(block.Data.capacity());
+
+	uint8_t *OutPlanes[1] = { static_cast<uint8_t *>(&block.Data[old_size]) };
+	swr_convert(ResampleContext,
+		OutPlanes, DecodeFrame->nb_samples,
+		(const uint8_t **)DecodeFrame->extended_data, DecodeFrame->nb_samples);
+#else  
 	int width = av_get_bytes_per_sample(CodecContext->sample_fmt);
 	uint8_t **Data = DecodeFrame->extended_data;
 
@@ -251,6 +278,7 @@ void FFMS_AudioSource::ResampleAndCache(CacheIterator pos) {
 		for (int c = 0; c < CodecContext->channels; ++c)
 			block.Data.insert(block.Data.end(), &Data[c][s * width], &Data[c][(s + 1) * width]);
 	}
+#endif
 #endif
 }
 

--- a/src/core/audiosource.cpp
+++ b/src/core/audiosource.cpp
@@ -182,7 +182,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"Sample rate changes are currently unsupported.");
 
-#ifndef WITH_AVRESAMPLE
+#ifndef FFMS_RESAMPLING_ENABLED
 	if (opt.SampleFormat != AP.SampleFormat || opt.SampleRate != AP.SampleRate || opt.ChannelLayout != AP.ChannelLayout)
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"FFMS was not built with resampling enabled. The only supported conversion is interleaving planar audio.");
@@ -201,7 +201,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 		opt.ChannelLayout != AP.ChannelLayout ||
 		opt.ForceResample;
 
-#ifdef WITH_AVRESAMPLE
+#ifdef FFMS_RESAMPLING_ENABLED
 	if (!NeedsResample) return;
 
 	FFResampleContext newContext;
@@ -210,7 +210,11 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 	av_opt_set_int(newContext, "in_sample_fmt", CodecContext->sample_fmt, 0);
 	av_opt_set_int(newContext, "in_channel_layout", AP.ChannelLayout, 0);
 
-	if (avresample_open(newContext))
+	av_opt_set_channel_layout(newContext, "out_channel_layout", opt.ChannelLayout, 0);
+	av_opt_set_int(newContext, "out_sample_rate", opt.SampleRate, 0);
+	av_opt_set_sample_fmt(newContext, "out_sample_fmt", (AVSampleFormat)opt.SampleFormat, 0);
+
+	if (ffms_open(newContext))
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNKNOWN,
 			"Could not open avresample context");
 	newContext.swap(ResampleContext);
@@ -218,7 +222,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 }
 
 std::unique_ptr<FFMS_ResampleOptions> FFMS_AudioSource::CreateResampleOptions() const {
-#ifdef WITH_AVRESAMPLE
+#ifdef FFMS_RESAMPLING_ENABLED
 	auto ret = ReadOptions(ResampleContext, resample_options);
 #else
 	auto ret = make_unique<FFMS_ResampleOptions>();
@@ -236,13 +240,13 @@ void FFMS_AudioSource::ResampleAndCache(CacheIterator pos) {
 	size_t new_req = DecodeFrame->nb_samples * BytesPerSample;
 	block.Data.reserve(old_size + new_req);
 
-#ifdef WITH_AVRESAMPLE
+#ifdef FFMS_RESAMPLING_ENABLED
 	block.Data.resize(block.Data.capacity());
 
 	uint8_t *OutPlanes[1] = { static_cast<uint8_t *>(&block.Data[old_size]) };
-	avresample_convert(ResampleContext,
-		OutPlanes, new_req, DecodeFrame->nb_samples,
-		DecodeFrame->extended_data, DecodeFrame->nb_samples * av_get_bytes_per_sample(CodecContext->sample_fmt), DecodeFrame->nb_samples);
+	ffms_convert(ResampleContext,
+		OutPlanes, DecodeFrame->nb_samples, BytesPerSample, DecodeFrame->nb_samples,
+		DecodeFrame->extended_data, DecodeFrame->nb_samples, av_get_bytes_per_sample(CodecContext->sample_fmt), DecodeFrame->nb_samples);
 #else
 	int width = av_get_bytes_per_sample(CodecContext->sample_fmt);
 	uint8_t **Data = DecodeFrame->extended_data;

--- a/src/core/audiosource.cpp
+++ b/src/core/audiosource.cpp
@@ -182,7 +182,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"Sample rate changes are currently unsupported.");
 
-#ifndef FFMS_RESAMPLING_ENABLED
+#ifndef WITH_AVRESAMPLE
 	if (opt.SampleFormat != AP.SampleFormat || opt.SampleRate != AP.SampleRate || opt.ChannelLayout != AP.ChannelLayout)
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNSUPPORTED,
 			"FFMS was not built with resampling enabled. The only supported conversion is interleaving planar audio.");
@@ -201,7 +201,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 		opt.ChannelLayout != AP.ChannelLayout ||
 		opt.ForceResample;
 
-#ifdef FFMS_RESAMPLING_ENABLED
+#ifdef WITH_AVRESAMPLE
 	if (!NeedsResample) return;
 
 	FFResampleContext newContext;
@@ -210,11 +210,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 	av_opt_set_int(newContext, "in_sample_fmt", CodecContext->sample_fmt, 0);
 	av_opt_set_int(newContext, "in_channel_layout", AP.ChannelLayout, 0);
 
-	av_opt_set_channel_layout(newContext, "out_channel_layout", opt.ChannelLayout, 0);
-	av_opt_set_int(newContext, "out_sample_rate", opt.SampleRate, 0);
-	av_opt_set_sample_fmt(newContext, "out_sample_fmt", (AVSampleFormat)opt.SampleFormat, 0);
-
-	if (ffms_open(newContext))
+	if (avresample_open(newContext))
 		throw FFMS_Exception(FFMS_ERROR_RESAMPLING, FFMS_ERROR_UNKNOWN,
 			"Could not open avresample context");
 	newContext.swap(ResampleContext);
@@ -222,7 +218,7 @@ void FFMS_AudioSource::SetOutputFormat(FFMS_ResampleOptions const& opt) {
 }
 
 std::unique_ptr<FFMS_ResampleOptions> FFMS_AudioSource::CreateResampleOptions() const {
-#ifdef FFMS_RESAMPLING_ENABLED
+#ifdef WITH_AVRESAMPLE
 	auto ret = ReadOptions(ResampleContext, resample_options);
 #else
 	auto ret = make_unique<FFMS_ResampleOptions>();
@@ -240,13 +236,13 @@ void FFMS_AudioSource::ResampleAndCache(CacheIterator pos) {
 	size_t new_req = DecodeFrame->nb_samples * BytesPerSample;
 	block.Data.reserve(old_size + new_req);
 
-#ifdef FFMS_RESAMPLING_ENABLED
+#ifdef WITH_AVRESAMPLE
 	block.Data.resize(block.Data.capacity());
 
 	uint8_t *OutPlanes[1] = { static_cast<uint8_t *>(&block.Data[old_size]) };
-	ffms_convert(ResampleContext,
-		OutPlanes, DecodeFrame->nb_samples, BytesPerSample, DecodeFrame->nb_samples,
-		DecodeFrame->extended_data, DecodeFrame->nb_samples, av_get_bytes_per_sample(CodecContext->sample_fmt), DecodeFrame->nb_samples);
+	avresample_convert(ResampleContext,
+		OutPlanes, new_req, DecodeFrame->nb_samples,
+		DecodeFrame->extended_data, DecodeFrame->nb_samples * av_get_bytes_per_sample(CodecContext->sample_fmt), DecodeFrame->nb_samples);
 #else
 	int width = av_get_bytes_per_sample(CodecContext->sample_fmt);
 	uint8_t **Data = DecodeFrame->extended_data;

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -32,6 +32,9 @@ extern "C" {
 #ifdef WITH_AVRESAMPLE
 #include <libavresample/avresample.h>
 #endif
+#ifdef WITH_SWRESAMPLE
+#include <libswresample/swresample.h>
+#endif
 }
 
 // must be included after ffmpeg headers
@@ -124,8 +127,8 @@ public:
 	}
 };
 
-#ifdef WITH_AVRESAMPLE
-typedef unknown_size<AVAudioResampleContext, avresample_alloc_context, avresample_free> FFResampleContext;
+#ifdef FFMS_RESAMPLING_ENABLED
+typedef unknown_size<FFMS_ResampleContext, ffms_resample_alloc_context, ffms_resample_free> FFResampleContext;
 #else
 typedef struct {} FFResampleContext;
 #endif

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -32,9 +32,6 @@ extern "C" {
 #ifdef WITH_AVRESAMPLE
 #include <libavresample/avresample.h>
 #endif
-#ifdef WITH_SWRESAMPLE
-#include <libswresample/swresample.h>
-#endif
 }
 
 // must be included after ffmpeg headers
@@ -127,8 +124,8 @@ public:
 	}
 };
 
-#ifdef FFMS_RESAMPLING_ENABLED
-typedef unknown_size<FFMS_ResampleContext, ffms_resample_alloc_context, ffms_resample_free> FFResampleContext;
+#ifdef WITH_AVRESAMPLE
+typedef unknown_size<AVAudioResampleContext, avresample_alloc_context, avresample_free> FFResampleContext;
 #else
 typedef struct {} FFResampleContext;
 #endif

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -32,6 +32,9 @@ extern "C" {
 #ifdef WITH_AVRESAMPLE
 #include <libavresample/avresample.h>
 #endif
+#ifdef WITH_SWRESAMPLE
+#include <libswresample/swresample.h>
+#endif
 }
 
 // must be included after ffmpeg headers
@@ -127,7 +130,11 @@ public:
 #ifdef WITH_AVRESAMPLE
 typedef unknown_size<AVAudioResampleContext, avresample_alloc_context, avresample_free> FFResampleContext;
 #else
+#ifdef WITH_SWRESAMPLE
+typedef unknown_size<SwrContext, swr_alloc, swr_free> FFResampleContext;
+#else
 typedef struct {} FFResampleContext;
+#endif 
 #endif
 
 void ClearErrorInfo(FFMS_ErrorInfo *ErrorInfo);

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -32,9 +32,6 @@ extern "C" {
 #ifdef WITH_AVRESAMPLE
 #include <libavresample/avresample.h>
 #endif
-#ifdef WITH_SWRESAMPLE
-#include <libswresample/swresample.h>
-#endif
 }
 
 // must be included after ffmpeg headers
@@ -130,11 +127,7 @@ public:
 #ifdef WITH_AVRESAMPLE
 typedef unknown_size<AVAudioResampleContext, avresample_alloc_context, avresample_free> FFResampleContext;
 #else
-#ifdef WITH_SWRESAMPLE
-typedef unknown_size<SwrContext, swr_alloc, swr_free> FFResampleContext;
-#else
 typedef struct {} FFResampleContext;
-#endif 
 #endif
 
 void ClearErrorInfo(FFMS_ErrorInfo *ErrorInfo);


### PR DESCRIPTION
+ actual supporting swresample instead of avresample (was already configurable with WITH_SWRESAMPLE)
+ supporting VS compiled FFMPEG/AV libs