### PR TITLE
ffms2-api.md: Use 4-spaces indentation for sublists

### DIFF
--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -18,8 +18,8 @@ FFMS2's video frame and audio sample retrieval functions are not threadsafe; you
 FFMS2 has the following dependencies:
 
  - **[Libav][libav]** or **[FFmpeg][ffmpeg]** (mpv has [a decent overview of the differences](https://github.com/mpv-player/mpv/wiki/FFmpeg-versus-Libav) if you have no idea which one to pick).
-  - At least 0.8 for libav and 0.9 for FFmpeg.
-  - Further recommended configuration options: `--disable-debug --disable-muxers --disable-encoders --disable-filters --disable-hwaccels --disable-network --disable-devices --enable-runtime-cpudetect` (runtime cpudetect in particular is a good idea if you are planning on distributing the library; not disabling debug results in a gigantic dll).
+    - At least 0.8 for libav and 0.9 for FFmpeg.
+    - Further recommended configuration options: `--disable-debug --disable-muxers --disable-encoders --disable-filters --disable-hwaccels --disable-network --disable-devices --enable-runtime-cpudetect` (runtime cpudetect in particular is a good idea if you are planning on distributing the library; not disabling debug results in a gigantic dll).
  - **[zlib][zlib]**
 
 Compiling the library on non-Windows is trivial; the usual `./configure && make && make install` will suffice if FFmpeg and zlib are installed to the default locations.


### PR DESCRIPTION
According to http://daringfireball.net/projects/markdown/syntax#list:

> Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab.

This applies to any block level elements nested in a list, including paragraphs, sub-lists, blockquotes, code blocks, etc. They must always be indented by at least four spaces (or one tab) for each level of
nesting.

In Debian/Ubuntu we use python-markdown and pandoc which are [not allowing](http://johnmacfarlane.net/babelmark2/?text=-+Item+1%0A++-+Item+2%0A++-+Item+3%0A-+Item+4) less than 4 spaces.