### PR TITLE
videoutils: Drop bitexact swscale flag

### DIFF
--- a/src/core/videoutils.cpp
+++ b/src/core/videoutils.cpp
@@ -30,7 +30,7 @@ extern "C" {
 }
 
 SwsContext *GetSwsContext(int SrcW, int SrcH, PixelFormat SrcFormat, int SrcColorSpace, int SrcColorRange, int DstW, int DstH, PixelFormat DstFormat, int DstColorSpace, int DstColorRange, int64_t Flags) {
-	Flags |= SWS_FULL_CHR_H_INT | SWS_FULL_CHR_H_INP | SWS_ACCURATE_RND | SWS_BITEXACT;
+	Flags |= SWS_FULL_CHR_H_INT | SWS_FULL_CHR_H_INP | SWS_ACCURATE_RND;
 	SwsContext *Context = sws_alloc_context();
 	if (!Context) return nullptr;
 


### PR DESCRIPTION
It has no visual effect, and it makes stuff slower, as it disables some
asm. Its main purpose is for internal swscale testing.