### PR TITLE
lavfindexer: Discard any packets we don't index

### DIFF
--- a/src/core/lavfindexer.cpp
+++ b/src/core/lavfindexer.cpp
@@ -42,9 +42,14 @@ public:
 				"Couldn't find stream information");
 		}
 
-		for (unsigned int i = 0; i < FormatContext->nb_streams; i++)
-			if (FormatContext->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
-				IndexMask[i] = false;
+		for (unsigned int i = 0; i < FormatContext->nb_streams; i++) {
+			if (IndexMask.count(i)) {
+				if (FormatContext->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
+					IndexMask[i] = false;
+			} else {
+				FormatContext->streams[i]->discard = AVDISCARD_ALL;
+			}
+		}
 	}
 
 	~FFLAVFIndexer() {


### PR DESCRIPTION
Speeds up indexing considerably on files with many tracks we do not index.

Also, do not set IndexMask to anything if the key doesn't exist.