### PR TITLE
indexing: Add an index version

### DIFF
--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((2 << 24) | (22 << 16) | (0 << 8) | 0)
+#define FFMS_VERSION ((2 << 24) | (22 << 16) | (0 << 8) | 1)
 
 #include <stdint.h>
 

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -35,6 +35,7 @@ extern "C" {
 }
 
 #define INDEXID 0x53920873
+#define INDEX_VERSION 1
 
 SharedVideoContext::~SharedVideoContext() {
 	if (CodecContext) {
@@ -130,6 +131,7 @@ void FFMS_Index::WriteIndex(const char *IndexFile) {
 	// Write the index file header
 	zf.Write<uint32_t>(INDEXID);
 	zf.Write<uint32_t>(FFMS_VERSION);
+	zf.Write<uint16_t>(INDEX_VERSION);
 	zf.Write<uint32_t>(size());
 	zf.Write<uint32_t>(Decoder);
 	zf.Write<uint32_t>(ErrorHandling);
@@ -155,6 +157,10 @@ FFMS_Index::FFMS_Index(const char *IndexFile) {
 			std::string("'") + IndexFile + "' is not a valid index file");
 
 	if (zf.Read<uint32_t>() != FFMS_VERSION)
+		throw FFMS_Exception(FFMS_ERROR_PARSER, FFMS_ERROR_FILE_READ,
+			std::string("'") + IndexFile + "' was not created with the expected FFMS2 version");
+
+	if (zf.Read<uint16_t>() != INDEX_VERSION)
 		throw FFMS_Exception(FFMS_ERROR_PARSER, FFMS_ERROR_FILE_READ,
 			std::string("'") + IndexFile + "' is not the expected index version");
 


### PR DESCRIPTION
This can be useful for extracting information, when you don't actually
intend to decode anything.

It is written after the FFMS2 version, and the minor FFMS2 version is
bumped, so that any ffindex files with the new format won't accidentally
be opened with an older FFMS2.

Signed-off-by: Derek Buitenhuis <derek.buitenhuis@gmail.com>