### PR TITLE
[RFC] Support Reading and Writing Index in Memory

### DIFF
--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -889,6 +889,16 @@ FFMS_Index *FFMS_ReadIndex(const char *IndexFile, FFMS_ErrorInfo *ErrorInfo);
 Attempts to read indexing information from the given `IndexFile`, which can be an absolute or relative path.
 Returns the `FFMS_Index` on success; returns `NULL` and sets `ErrorMsg` on failure.
 
+### FFMS_ReadIndexFromBuffer - reads an index from a user-supplied buffer
+
+[ReadIndexFromBuffer]: #ffms_readindexfrombffer---reads-an-index-from-a-user-supplied-buffer
+```c++
+FFMS_Index *FFMS_ReadIndexFromBuffer(const uint8_t *Buffer, size_t Size, FFMS_ErrorInfo *ErrorInfo);
+```
+
+Attempts to read indexing information from the super supplied buffer, `Buffer, of size `Size`.
+Returns the `FFMS_Index` on success; returns `NULL` and sets `ErrorMsg` on failure.
+
 ### FFMS_IndexBelongsToFile - check if a given index belongs to a given file
 
 [IndexBelongsToFile]: #ffms_indexbelongstofile---check-if-a-given-index-belongs-to-a-given-file
@@ -918,6 +928,25 @@ int FFMS_WriteIndex(const char *IndexFile, FFMS_Index *TrackIndices, FFMS_ErrorI
 ```
 Writes the indexing information from the given `FFMS_Index` to the given `IndexFile` (which can be an absolute or relative path; it will be truncated and overwritten if it already exists).
 Returns 0 on success; returns non-0 and sets `ErrorMsg` on failure.
+
+### FFMS_WriteIndexToBuffer - writes an index to memory
+
+[WriteIndexToBuffer]: #ffms_writeindextobuffer---writes-an-index-to-memory
+```c++
+int FFMS_WriteIndexToBuffer(uint8_t **BufferPtr, size_t *Size, FFMS_Index *Index, FFMS_ErrorInfo *ErrorInfo)
+```
+
+Writes the indexing information from the given `FFMS_Index` to memory, and sets `BufferPtr` to point to the buffer, and `Size` to the size of the returned buffer. Users are required to free the resulting buffer with [FFMS_FreeIndexBuffer][FreeIndexBuffer].
+Returns 0 on success; returns non-0 and sets `ErrorMsg` on failure.
+
+### FFMS_FreeIndexBuffer - frees a buffer allocated by [FFMS_WriteIndexToBuffer][WriteIndexToBuffer]
+
+[FreeIndexBuffer]: #ffms_freeindexbuffer---frees-a-buffer-alloctaed-by-ffms_writeindextobuffer
+```c++
+void FFMS_FreeIndexBuffer(uint8_t **BufferPtr)
+```
+
+Frees the buffer pointed to by `BufferPtr` and sets it to NULL.
 
 ### FFMS_GetPixFmt - gets a colorspace identifier from a colorspace name
 

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,9 +22,10 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((2 << 24) | (22 << 16) | (0 << 8) | 1)
+#define FFMS_VERSION ((2 << 24) | (22 << 16) | (1 << 8) | 0)
 
 #include <stdint.h>
+#include <stddef.h>
 
 
 /********
@@ -451,8 +452,11 @@ FFMS_API(void) FFMS_SetProgressCallback(FFMS_Indexer *Indexer, TIndexCallback IC
 FFMS_API(FFMS_Index *) FFMS_DoIndexing2(FFMS_Indexer *Indexer, int ErrorHandling, FFMS_ErrorInfo *ErrorInfo); /* Introduced in FFMS_VERSION ((2 << 24) | (21 << 16) | (0 << 8) | 0) */
 FFMS_API(void) FFMS_CancelIndexing(FFMS_Indexer *Indexer);
 FFMS_API(FFMS_Index *) FFMS_ReadIndex(const char *IndexFile, FFMS_ErrorInfo *ErrorInfo);
+FFMS_API(FFMS_Index *) FFMS_ReadIndexFromBuffer(const uint8_t *Buffer, size_t Size, FFMS_ErrorInfo *ErrorInfo);
 FFMS_API(int) FFMS_IndexBelongsToFile(FFMS_Index *Index, const char *SourceFile, FFMS_ErrorInfo *ErrorInfo);
 FFMS_API(int) FFMS_WriteIndex(const char *IndexFile, FFMS_Index *Index, FFMS_ErrorInfo *ErrorInfo);
+FFMS_API(int) FFMS_WriteIndexToBuffer(uint8_t **BufferPtr, size_t *Size, FFMS_Index *Index, FFMS_ErrorInfo *ErrorInfo);
+FFMS_API(void) FFMS_FreeIndexBuffer(uint8_t **BufferPtr);
 FFMS_API(int) FFMS_GetPixFmt(const char *Name);
 FFMS_API(int) FFMS_GetPresentSources();
 FFMS_API(int) FFMS_GetEnabledSources();

--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -456,7 +456,7 @@ FFMS_API(int) FFMS_IndexBelongsToFile(FFMS_Index *Index, const char *SourceFile,
 FFMS_API(int) FFMS_WriteIndex(const char *IndexFile, FFMS_Index *Index, FFMS_ErrorInfo *ErrorInfo) {
 	ClearErrorInfo(ErrorInfo);
 	try {
-		Index->WriteIndex(IndexFile);
+		Index->WriteIndexFile(IndexFile);
 	} catch (FFMS_Exception &e) {
 		return e.CopyOut(ErrorInfo);
 	}

--- a/src/core/filehandle.h
+++ b/src/core/filehandle.h
@@ -33,6 +33,7 @@ class FileHandle {
 
 public:
 	FileHandle(const char *filename, const char *mode, int error_source, int error_cause);
+	FileHandle() : avio(nullptr) {}
 	~FileHandle();
 
 	void Seek(int64_t offset, int origin);

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -123,9 +123,7 @@ bool FFMS_Index::CompareFileSignature(const char *Filename) {
 	return (CFilesize == Filesize && !memcmp(CDigest, Digest, sizeof(Digest)));
 }
 
-void FFMS_Index::WriteIndex(const char *IndexFile) {
-	ZipFile zf(IndexFile, "wb");
-
+void FFMS_Index::WriteIndex(ZipFile &zf) {
 	// Write the index file header
 	zf.Write<uint32_t>(INDEXID);
 	zf.Write<uint32_t>(FFMS_VERSION);
@@ -146,9 +144,13 @@ void FFMS_Index::WriteIndex(const char *IndexFile) {
 	zf.Finish();
 }
 
-FFMS_Index::FFMS_Index(const char *IndexFile) {
-	ZipFile zf(IndexFile, "rb");
+void FFMS_Index::WriteIndexFile(const char *IndexFile) {
+	ZipFile zf(IndexFile, "wb");
 
+	WriteIndex(zf);
+}
+
+void FFMS_Index::ReadIndex(ZipFile &zf, const char *IndexFile) {
 	// Read the index file header
 	if (zf.Read<uint32_t>() != INDEXID)
 		throw FFMS_Exception(FFMS_ERROR_PARSER, FFMS_ERROR_FILE_READ,
@@ -192,6 +194,12 @@ FFMS_Index::FFMS_Index(const char *IndexFile) {
 		throw FFMS_Exception(FFMS_ERROR_PARSER, FFMS_ERROR_FILE_READ,
 			std::string("Unknown error while reading index information in '") + IndexFile + "'");
 	}
+}
+
+FFMS_Index::FFMS_Index(const char *IndexFile) {
+	ZipFile zf(IndexFile, "rb");
+
+	ReadIndex(zf, IndexFile);
 }
 
 FFMS_Index::FFMS_Index(int64_t Filesize, uint8_t Digest[20], int Decoder, int ErrorHandling)

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -150,6 +150,14 @@ void FFMS_Index::WriteIndexFile(const char *IndexFile) {
 	WriteIndex(zf);
 }
 
+uint8_t *FFMS_Index::WriteIndexBuffer(size_t *Size) {
+	ZipFile zf;
+
+	WriteIndex(zf);
+
+	return zf.GetBuffer(Size);
+}
+
 void FFMS_Index::ReadIndex(ZipFile &zf, const char *IndexFile) {
 	// Read the index file header
 	if (zf.Read<uint32_t>() != INDEXID)
@@ -200,6 +208,12 @@ FFMS_Index::FFMS_Index(const char *IndexFile) {
 	ZipFile zf(IndexFile, "rb");
 
 	ReadIndex(zf, IndexFile);
+}
+
+FFMS_Index::FFMS_Index(const uint8_t *Buffer, size_t Size) {
+	ZipFile zf(Buffer, Size);
+
+	ReadIndex(zf, "User supplied buffer");
 }
 
 FFMS_Index::FFMS_Index(int64_t Filesize, uint8_t Digest[20], int Decoder, int ErrorHandling)

--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -64,8 +64,10 @@ public:
 	void Finalize(std::vector<SharedVideoContext> const& video_contexts);
 	bool CompareFileSignature(const char *Filename);
 	void WriteIndexFile(const char *IndexFile);
+	uint8_t *WriteIndexBuffer(size_t *Size);
 
 	FFMS_Index(const char *IndexFile);
+	FFMS_Index(const uint8_t *Buffer, size_t Size);
 	FFMS_Index(int64_t Filesize, uint8_t Digest[20], int Decoder, int ErrorHandling);
 };
 

--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -27,6 +27,7 @@
 #include <memory>
 
 class Wave64Writer;
+class ZipFile;
 
 struct SharedVideoContext {
 	AVCodecContext *CodecContext = nullptr;
@@ -47,6 +48,8 @@ struct FFMS_Index : public std::vector<FFMS_Track> {
 	int RefCount = 1;
 	FFMS_Index(FFMS_Index const&) = delete;
 	FFMS_Index& operator=(FFMS_Index const&) = delete;
+	void ReadIndex(ZipFile &zf, const char* IndexFile);
+	void WriteIndex(ZipFile &zf);
 public:
 	static void CalculateFileSignature(const char *Filename, int64_t *Filesize, uint8_t Digest[20]);
 
@@ -60,7 +63,7 @@ public:
 
 	void Finalize(std::vector<SharedVideoContext> const& video_contexts);
 	bool CompareFileSignature(const char *Filename);
-	void WriteIndex(const char *IndexFile);
+	void WriteIndexFile(const char *IndexFile);
 
 	FFMS_Index(const char *IndexFile);
 	FFMS_Index(int64_t Filesize, uint8_t Digest[20], int Decoder, int ErrorHandling);

--- a/src/core/zipfile.h
+++ b/src/core/zipfile.h
@@ -18,6 +18,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#ifndef ZIPFILE_H
+#define ZIPFILE_H
+
 #include "filehandle.h"
 
 #include <vector>
@@ -53,3 +56,5 @@ public:
 		Write(&value, sizeof value);
 	}
 };
+
+#endif

--- a/src/core/zipfile.h
+++ b/src/core/zipfile.h
@@ -29,6 +29,8 @@
 class ZipFile {
 	FileHandle file;
 	std::vector<char> buffer;
+	std::vector<uint8_t> index_buffer;
+	bool is_file;
 	z_stream z;
 	enum {
 		Initial,
@@ -38,11 +40,14 @@ class ZipFile {
 
 public:
 	ZipFile(const char *filename, const char *mode);
+	ZipFile(const uint8_t *in_buffer, const size_t size);
+	ZipFile();
 	~ZipFile();
 
 	void Read(void *buffer, size_t size);
 	int Write(const void *buffer, size_t size);
 	void Finish();
+	uint8_t *GetBuffer(size_t *size);
 
 	template<typename T>
 	T Read() {


### PR DESCRIPTION
I've tested this in my own code, as well as a hacked up copy of `ffmsindex`.

I am hardly a C++ expert, nor an expert on FFMS2's internal design, so comments, ideas, problems, etc. are very welcome.