### PR TITLE
indexing: Do not use a parser to determine VP8 show_frame properties

### DIFF
--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -81,7 +81,6 @@ FFMS_API(void) FFMS_Init(int, int) {
     std::call_once(FFmpegOnce, []() {
         av_register_all();
         avformat_network_init();
-        RegisterCustomParsers();
 #ifdef FFMS_WIN_DEBUG
         av_log_set_callback(av_log_windebug_callback);
         av_log_set_level(AV_LOG_INFO);

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -21,6 +21,7 @@
 #include "indexing.h"
 
 #include "track.h"
+#include "videoutils.h"
 #include "wave64writer.h"
 #include "zipfile.h"
 
@@ -391,4 +392,7 @@ void FFMS_Indexer::ParseVideoPacket(SharedVideoContext &VideoContext, AVPacket &
     } else {
         *Invisible = !!(pkt.flags & AV_PKT_FLAG_DISCARD);
     }
+
+    if (VideoContext.CodecContext->codec_id == AV_CODEC_ID_VP8)
+        ParseVP8(pkt.data[0], Invisible, FrameType);
 }

--- a/src/core/videoutils.cpp
+++ b/src/core/videoutils.cpp
@@ -246,22 +246,7 @@ AVPixelFormat FindBestPixelFormat(const std::vector<AVPixelFormat> &Dsts, AVPixe
     return Loss.Format;
 }
 
-namespace {
-    int parse_vp8(AVCodecParserContext *s,
-        AVCodecContext *,
-        const uint8_t **poutbuf, int *poutbuf_size,
-        const uint8_t *buf, int buf_size) {
-        s->pict_type = (buf[0] & 0x01) ? AV_PICTURE_TYPE_P : AV_PICTURE_TYPE_I;
-        s->repeat_pict = (buf[0] & 0x10) ? 0 : -1;
-
-        *poutbuf = buf;
-        *poutbuf_size = buf_size;
-        return buf_size;
-    }
-
-    AVCodecParser ffms_vp8_parser = { { AV_CODEC_ID_VP8 }, 0, nullptr, parse_vp8, nullptr, nullptr, nullptr };
-}
-
-void RegisterCustomParsers() {
-    av_register_codec_parser(&ffms_vp8_parser);
+void ParseVP8(const uint8_t Buf, bool *Invisible, int *PictType) {
+    *PictType = (Buf & 0x01) ? AV_PICTURE_TYPE_P : AV_PICTURE_TYPE_I;
+    *Invisible = (*Invisible || !(Buf & 0x10));
 }

--- a/src/core/videoutils.h
+++ b/src/core/videoutils.h
@@ -43,4 +43,5 @@ void CorrectTimebase(FFMS_VideoProperties *VP, FFMS_TrackTimeBase *TTimebase);
 // our implementation of avcodec_find_best_pix_fmt()
 AVPixelFormat FindBestPixelFormat(const std::vector<AVPixelFormat> &Dsts, AVPixelFormat Src);
 
-void RegisterCustomParsers();
+// handling of alt-refs in VP8
+void ParseVP8(const uint8_t Buf, bool *Invisible, int *PictType);


### PR DESCRIPTION
This is the groundwork for upcoming VP9 alt-ref and superframe support.

VP9 already has a parser inside FFmpeg, so we can't register our own, like we do for VP8, so to ready the codebase for this change, this commit separates out the VP8 "parser" into FFMS itself.

---

This needs some indexing and seeking testing visually with VP8 files before it is merged, and a good look-over by @tgoyne. #