### PR TITLE
API: Add FFMS_Deinit

### DIFF
--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -133,6 +133,9 @@ int main (...) {
   /* now it's time to clean up */
   FFMS_DestroyVideoSource(videosource);
 
+  /* uninitialize the library. */
+  FFMS_Deinit();
+
   return 0;
 }
 ```
@@ -200,6 +203,16 @@ This argument is no longer used and is left only for API/ABI compatibility. Pass
 ##### `int Unused2`
 
 This argument is also no longer used and is left only for API/ABI compatibility. Pass 0.
+
+### FFMS_Deinit - deinitializes the library
+
+[Deinit]: ##ffms_deinit---deinitializes-the-library
+```c++
+void FFMS_Deinit()
+```
+Deinitializes the FFMS2 library.
+This function must be called once at the end of your program, and no more FFMS2 function calls must be made.
+This function is threadsafe and will only be run once.
 
 ### FFMS_GetLogLevel - gets FFmpeg message level
 

--- a/doc/ffms2-changelog.md
+++ b/doc/ffms2-changelog.md
@@ -21,6 +21,7 @@
   - Removed support for old FFmpeg versions (Myrsloik)
   - Removed libav support (Myrsloik)
   - Discontinuous Timestamp Support (Daemon404)
+  - Add FFMS_Deinit (Daemon404)
 
 - 2.23
   - Updated FFmpeg APIs used (Daemon404)

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((2 << 24) | (25 << 16) | (0 << 8) | 0)
+#define FFMS_VERSION ((2 << 24) | (26 << 16) | (0 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -446,6 +446,7 @@ typedef int (FFMS_CC *TAudioNameCallback)(const char *SourceFile, int Track, con
 // Functions without error message output can be assumed to never fail in a graceful way
 // FIXME IGNORES BOTH ARGUMENTS
 FFMS_API(void) FFMS_Init(int, int);
+FFMS_API(void) FFMS_Deinit();
 FFMS_API(int) FFMS_GetVersion();
 FFMS_API(int) FFMS_GetLogLevel();
 FFMS_API(void) FFMS_SetLogLevel(int Level);

--- a/src/index/ffmsindex.cpp
+++ b/src/index/ffmsindex.cpp
@@ -275,8 +275,10 @@ int main(int argc, const char *argv[]) {
         DoIndexing();
     } catch (Error const& e) {
         std::cout << e.msg << std::endl;
+        FFMS_Deinit();
         return 1;
     }
 
+    FFMS_Deinit();
     return 0;
 }

--- a/src/vapoursynth/vapoursource.cpp
+++ b/src/vapoursynth/vapoursource.cpp
@@ -200,6 +200,7 @@ const VSFrameRef *VS_CC VSVideoSource::GetFrame(int n, int activationReason, voi
 }
 
 void VS_CC VSVideoSource::Free(void *instanceData, VSCore *, const VSAPI *) {
+    FFMS_Deinit();
     delete static_cast<VSVideoSource *>(instanceData);
 }
 

--- a/src/vapoursynth/vapoursynth.cpp
+++ b/src/vapoursynth/vapoursynth.cpp
@@ -93,6 +93,7 @@ static void VS_CC CreateIndex(const VSMap *in, VSMap *out, void *, VSCore *, con
         FFMS_DestroyIndex(Index);
         vsapi->propSetData(out, "result", "Valid index already exists", -1, paReplace);
     }
+    FFMS_Deinit();
 }
 
 static void VS_CC CreateSource(const VSMap *in, VSMap *out, void *, VSCore *core, const VSAPI *vsapi) {


### PR DESCRIPTION
Because libavformat is great, and TLS libraries are great, and network
stacks are great, libavformat has some global state init functions that
do not need to be inited, and must only be run once, and also some other
global state init functions that must be deinited upon program exit,
and reinited if used again.

To this end, I've implemented this with a lock, so it can be re-inited
after deinit safely, if the user wants to do that for some reason.

NOTE: I have not updated the AviSynth plugin to use this, since I can't figure out where the hell to put the `FFMS_Deinit()` call, because lolexceptionsforflowcontrol.