### PR TITLE
mastering display and content light level

### DIFF
--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -1151,6 +1151,9 @@ typedef struct {
   int HasMasteringDisplayLuminance;
   double MasteringDisplayMinLuminance;
   double MasteringDisplayMaxLuminance;
+  int HasContentLightLevel;
+  unsigned int ContentLightLevelMax;
+  unsigned int ContentLightLevelAverage;
 } FFMS_Frame;
 ```
 A struct representing a video frame.
@@ -1192,7 +1195,9 @@ The fields are:
  - `int HasMasteringDisplayLuminance;` - If this is non-zero, the following two properties are set.
  - `double MasteringDisplayMinLuminance;` - Minimum luminance of the mastering display (cd/m^2).
  - `double MasteringDisplayMaxLuminance;` - Maximum luminance of the mastering display (cd/m^2).
-
+ - `int HasContentLightLevel;` - If this is non-zero, the following two properties are set.
+ - `unsigned int ContentLightLevelMax;` - Maximum content luminance (cd/m^2).
+ - `unsigned int ContentLightLevelAverage;` - Average content luminance (cd/m^2).
 
 ### FFMS_TrackTimeBase
 

--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -1143,14 +1143,14 @@ typedef struct {
   int ColorPrimaries;
   int TransferCharateristics;
   int ChromaLocation;
-  int HasMDMDisplayPrimaries;
-  double MDMDisplayPrimariesX[3];
-  double MDMDisplayPrimariesY[3];
-  double MDMWhitePointX;
-  double MDMWhitePointY;
-  int HasMDMMinMaxLuminance;
-  double MDMMinLuminance;
-  double MDMMaxLuminance;
+  int HasMasteringDisplayPrimaries;
+  double MasteringDisplayPrimariesX[3];
+  double MasteringDisplayPrimariesY[3];
+  double MasteringDisplayWhitePointX;
+  double MasteringDisplayWhitePointY;
+  int HasMasteringDisplayLuminance;
+  double MasteringDisplayMinLuminance;
+  double MasteringDisplayMaxLuminance;
 } FFMS_Frame;
 ```
 A struct representing a video frame.
@@ -1184,14 +1184,14 @@ The fields are:
  - `int ColorPrimaries;` - Identifies the color primaries of the frame. Corresponds to [FFMS_ColorPrimaries][ColorPrimaries].
  - `int TransferCharateristics;` - Identifies the transfer characteristics of the frame. Corresponds to [FFMS_TransferCharacteristic][TransferCharacteristic].
  - `int ChromaLocation;` - Identifies the chroma location for the frame. Corresponds to [FFMS_ChromaLocations][ChromaLocations].
- - `int HasMDMDisplayPrimaries;` - If this is non-zero, the following four properties are set.
- - `double MDMDisplayPrimariesX[3];` - RGB chromaticy coordinates of the mastering display (x coord).
- - `double MDMDisplayPrimariesY[3];` - RGB chromaticy coordinates of the mastering display (y coord).
- - `double MDMWhitePointX;` - White point coordinate of the mastering display (x coord).
- - `double MDMWhitePointY;` - White point coordinate of the mastering display (y coord).
- - `int HasMDMMinMaxLuminance;` - If this is non-zero, the following two properties are set.
- - `double MDMMinLuminance;` - Minimum luminance of the mastering display (cd/m^2).
- - `double MDMMaxLuminance;` - Maximum luminance of the mastering display (cd/m^2).
+ - `int HasMasteringDisplayPrimaries;` - If this is non-zero, the following four properties are set.
+ - `double MasteringDisplayPrimariesX[3];` - RGB chromaticy coordinates of the mastering display (x coord).
+ - `double MasteringDisplayPrimariesY[3];` - RGB chromaticy coordinates of the mastering display (y coord).
+ - `double MasteringDisplayWhitePointX;` - White point coordinate of the mastering display (x coord).
+ - `double MasteringDisplayWhitePointY;` - White point coordinate of the mastering display (y coord).
+ - `int HasMasteringDisplayLuminance;` - If this is non-zero, the following two properties are set.
+ - `double MasteringDisplayMinLuminance;` - Minimum luminance of the mastering display (cd/m^2).
+ - `double MasteringDisplayMaxLuminance;` - Maximum luminance of the mastering display (cd/m^2).
 
 
 ### FFMS_TrackTimeBase

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((2 << 24) | (26 << 16) | (0 << 8) | 0)
+#define FFMS_VERSION ((2 << 24) | (27 << 16) | (0 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -392,7 +392,7 @@ typedef struct FFMS_Frame {
     int ColorPrimaries;
     int TransferCharateristics;
     int ChromaLocation;
-    /* Introduced in FFMS_VERSION ((2 << 24) | (24 << 16) | (0 << 8) | 0) */
+    /* Introduced in FFMS_VERSION ((2 << 24) | (27 << 16) | (0 << 8) | 0) */
     int HasMasteringDisplayPrimaries;  /* Non-zero if the 4 fields below are valid */
     double MasteringDisplayPrimariesX[3];
     double MasteringDisplayPrimariesY[3];
@@ -401,6 +401,9 @@ typedef struct FFMS_Frame {
     int HasMasteringDisplayLuminance; /* Non-zero if the 2 fields below are valid */
     double MasteringDisplayMinLuminance;
     double MasteringDisplayMaxLuminance;
+    int HasContentLightLevel;
+    unsigned int ContentLightLevelMax;
+    unsigned int ContentLightLevelAverage;
 } FFMS_Frame;
 
 typedef struct FFMS_TrackTimeBase {

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -393,14 +393,14 @@ typedef struct FFMS_Frame {
     int TransferCharateristics;
     int ChromaLocation;
     /* Introduced in FFMS_VERSION ((2 << 24) | (24 << 16) | (0 << 8) | 0) */
-    int HasMDMDisplayPrimaries;  /* Non-zero if the 4 fields below are valid */
-    double MDMDisplayPrimariesX[3];
-    double MDMDisplayPrimariesY[3];
-    double MDMWhitePointX;
-    double MDMWhitePointY;
-    int HasMDMMinMaxLuminance; /* Non-zero if the 2 fields below are valid */
-    double MDMMinLuminance;
-    double MDMMaxLuminance;
+    int HasMasteringDisplayPrimaries;  /* Non-zero if the 4 fields below are valid */
+    double MasteringDisplayPrimariesX[3];
+    double MasteringDisplayPrimariesY[3];
+    double MasteringDisplayWhitePointX;
+    double MasteringDisplayWhitePointY;
+    int HasMasteringDisplayLuminance; /* Non-zero if the 2 fields below are valid */
+    double MasteringDisplayMinLuminance;
+    double MasteringDisplayMaxLuminance;
 } FFMS_Frame;
 
 typedef struct FFMS_TrackTimeBase {

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -109,6 +109,15 @@ FFMS_Frame *FFMS_VideoSource::OutputFrame(AVFrame *Frame) {
         }
     }
 
+    LocalFrame.HasContentLightLevel = 0;
+    const AVFrameSideData *ContentLightSideData = av_frame_get_side_data(Frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+    if (ContentLightSideData) {
+        const AVContentLightMetadata *ContentLightLevel = reinterpret_cast<const AVContentLightMetadata *>(ContentLightSideData->data);
+        LocalFrame.HasContentLightLevel = 1;
+        LocalFrame.ContentLightLevelMax = ContentLightLevel->MaxCLL;
+        LocalFrame.ContentLightLevelAverage = ContentLightLevel->MaxFALL;
+    }
+
     LastFrameHeight = Frame->height;
     LastFrameWidth = Frame->width;
     LastFramePixelFormat = (AVPixelFormat) Frame->format;

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -87,24 +87,25 @@ FFMS_Frame *FFMS_VideoSource::OutputFrame(AVFrame *Frame) {
     LocalFrame.ColorPrimaries = (OutputColorPrimaries >= 0) ? OutputColorPrimaries : Frame->color_primaries;
     LocalFrame.TransferCharateristics = (OutputTransferCharateristics >= 0) ? OutputTransferCharateristics : Frame->color_trc;
     LocalFrame.ChromaLocation = (OutputChromaLocation >= 0) ? OutputChromaLocation : Frame->chroma_location;
-    LocalFrame.HasMDMDisplayPrimaries = 0;
-    LocalFrame.HasMDMMinMaxLuminance = 0;
-    const AVFrameSideData *MDMSide = av_frame_get_side_data(Frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-    if (MDMSide) {
-        const AVMasteringDisplayMetadata *MDMData = reinterpret_cast<const AVMasteringDisplayMetadata *>(MDMSide->data);
-        if (MDMData->has_primaries) {
-            LocalFrame.HasMDMDisplayPrimaries = MDMData->has_primaries;
+
+    LocalFrame.HasMasteringDisplayPrimaries = 0;
+    LocalFrame.HasMasteringDisplayLuminance = 0;
+    const AVFrameSideData *MasteringDisplaySideData = av_frame_get_side_data(Frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+    if (MasteringDisplaySideData) {
+        const AVMasteringDisplayMetadata *MasteringDisplay = reinterpret_cast<const AVMasteringDisplayMetadata *>(MasteringDisplaySideData->data);
+        if (MasteringDisplay->has_primaries) {
+            LocalFrame.HasMasteringDisplayPrimaries = MasteringDisplay->has_primaries;
             for (int i = 0; i < 3; i++) {
-                LocalFrame.MDMDisplayPrimariesX[i] = av_q2d(MDMData->display_primaries[i][0]);
-                LocalFrame.MDMDisplayPrimariesY[i] = av_q2d(MDMData->display_primaries[i][1]);
+                LocalFrame.MasteringDisplayPrimariesX[i] = av_q2d(MasteringDisplay->display_primaries[i][0]);
+                LocalFrame.MasteringDisplayPrimariesY[i] = av_q2d(MasteringDisplay->display_primaries[i][1]);
             }
-            LocalFrame.MDMWhitePointX = av_q2d(MDMData->white_point[0]);
-            LocalFrame.MDMWhitePointY = av_q2d(MDMData->white_point[1]);
+            LocalFrame.MasteringDisplayWhitePointX = av_q2d(MasteringDisplay->white_point[0]);
+            LocalFrame.MasteringDisplayWhitePointY = av_q2d(MasteringDisplay->white_point[1]);
         }
-        if (MDMData->has_luminance) {
-            LocalFrame.HasMDMMinMaxLuminance = MDMData->has_luminance;
-            LocalFrame.MDMMinLuminance = av_q2d(MDMData->min_luminance);
-            LocalFrame.MDMMaxLuminance = av_q2d(MDMData->max_luminance);
+        if (MasteringDisplay->has_luminance) {
+            LocalFrame.HasMasteringDisplayLuminance = MasteringDisplay->has_luminance;
+            LocalFrame.MasteringDisplayMinLuminance = av_q2d(MasteringDisplay->min_luminance);
+            LocalFrame.MasteringDisplayMaxLuminance = av_q2d(MasteringDisplay->max_luminance);
         }
     }
 

--- a/src/vapoursynth/vapoursource.cpp
+++ b/src/vapoursynth/vapoursource.cpp
@@ -176,16 +176,16 @@ const VSFrameRef *VS_CC VSVideoSource::GetFrame(int n, int activationReason, voi
             FieldBased = (Frame->TopFieldFirst ? 2 : 1);
         vsapi->propSetInt(Props, "_FieldBased", FieldBased, paReplace);
 
-        if (Frame->HasMDMDisplayPrimaries) {
-            vsapi->propSetFloatArray(Props, "MDMDisplayPrimariesX", Frame->MDMDisplayPrimariesX, 3);
-            vsapi->propSetFloatArray(Props, "MDMDisplayPrimariesY", Frame->MDMDisplayPrimariesY, 3);
-            vsapi->propSetFloat(Props, "MDMWhitePointX", Frame->MDMWhitePointX, paReplace);
-            vsapi->propSetFloat(Props, "MDMWhitePointY", Frame->MDMWhitePointY, paReplace);
+        if (Frame->HasMasteringDisplayPrimaries) {
+            vsapi->propSetFloatArray(Props, "MasteringDisplayPrimariesX", Frame->MasteringDisplayPrimariesX, 3);
+            vsapi->propSetFloatArray(Props, "MasteringDisplayPrimariesY", Frame->MasteringDisplayPrimariesY, 3);
+            vsapi->propSetFloat(Props, "MasteringDisplayWhitePointX", Frame->MasteringDisplayWhitePointX, paReplace);
+            vsapi->propSetFloat(Props, "MasteringDisplayWhitePointY", Frame->MasteringDisplayWhitePointY, paReplace);
         }
 
-        if (Frame->HasMDMMinMaxLuminance) {
-            vsapi->propSetFloat(Props, "MDMMinLuminance", Frame->MDMMinLuminance, paReplace);
-            vsapi->propSetFloat(Props, "MDMMaxLuminance", Frame->MDMMaxLuminance, paReplace);
+        if (Frame->HasMasteringDisplayLuminance) {
+            vsapi->propSetFloat(Props, "MasteringDisplayMinLuminance", Frame->MasteringDisplayMinLuminance, paReplace);
+            vsapi->propSetFloat(Props, "MasteringDisplayMaxLuminance", Frame->MasteringDisplayMaxLuminance, paReplace);
         }
 
         if (OutputIndex == 0)

--- a/src/vapoursynth/vapoursource.cpp
+++ b/src/vapoursynth/vapoursource.cpp
@@ -188,6 +188,11 @@ const VSFrameRef *VS_CC VSVideoSource::GetFrame(int n, int activationReason, voi
             vsapi->propSetFloat(Props, "MasteringDisplayMaxLuminance", Frame->MasteringDisplayMaxLuminance, paReplace);
         }
 
+        if (Frame->HasContentLightLevel) {
+            vsapi->propSetFloat(Props, "ContentLightLevelMax", Frame->ContentLightLevelMax, paReplace);
+            vsapi->propSetFloat(Props, "ContentLightLevelAverage", Frame->ContentLightLevelAverage, paReplace);
+        }
+
         if (OutputIndex == 0)
             OutputFrame(Frame, Dst, vsapi);
         else


### PR DESCRIPTION
This PR addresses detection of hdr and its rendering.

- The first patch is purely cosmetic, it drops the MDM prefix that carries an overly long name when spelled out, as `MDMDisplayPrimaries` would stand for `Mastering Display Metadata Display Primaries`.
- The second patch adds content light level information from ffmpeg which is also needed for hdr.