### PR TITLE
Visibility / Time Fixes

### DIFF
--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -526,7 +526,8 @@ FFMS_Index *FFMS_Indexer::DoIndexing() {
                 StartSample, SampleCount, KeyFrame, Packet.pos, Packet.flags & AV_PKT_FLAG_DISCARD);
         }
 
-        TrackInfo.LastDuration = Packet.duration;
+        if (!(Packet.flags & AV_PKT_FLAG_DISCARD))
+            TrackInfo.LastDuration = Packet.duration;
 
         av_packet_unref(&Packet);
     }

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -491,9 +491,9 @@ void FFMS_VideoSource::SetVideoProperties() {
         VP.ColorRange = AVCOL_RANGE_JPEG;
 
 
-    VP.FirstTime = ((Frames.front().PTS * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
-    VP.LastTime = ((Frames.back().PTS * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
-    VP.LastEndTime = (((Frames.back().PTS + Frames.LastDuration) * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
+    VP.FirstTime = ((Frames[Frames.RealFrameNumber(0)].PTS * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
+    VP.LastTime = ((Frames[Frames.RealFrameNumber(Frames.VisibleFrameCount()-1)].PTS * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
+    VP.LastEndTime = (((Frames[Frames.RealFrameNumber(Frames.VisibleFrameCount()-1)].PTS + Frames.LastDuration) * Frames.TB.Num) / (double)Frames.TB.Den) / 1000;
 
     if (CodecContext->width <= 0 || CodecContext->height <= 0)
         throw FFMS_Exception(FFMS_ERROR_DECODING, FFMS_ERROR_CODEC,


### PR DESCRIPTION
Otherwise, files with edit lists, for example, can have incorrect start / end times.