### PR TITLE
indexing: Don't apply file-positon-based PAFF hacks to H.264 in ASF/WMV

### DIFF
--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -54,7 +54,7 @@ public:
     int64_t Filesize;
     uint8_t Digest[20];
 
-    void Finalize(std::vector<SharedAVContext> const& video_contexts);
+    void Finalize(std::vector<SharedAVContext> const& video_contexts, const char *Format);
     bool CompareFileSignature(const char *Filename);
     void WriteIndexFile(const char *IndexFile);
     uint8_t *WriteIndexBuffer(size_t *Size);


### PR DESCRIPTION
These files, as output by libavformat, include legitimate packets with with the same position as the old packet, since it splits packets, but does not adjust the position accordingly.

Prevents visible frames from being marked as hidden for H.264 in ASF/WMV.