### PR TITLE
Make sure we use the input timebase while generating the hashmap

### DIFF
--- a/test/tools/gendata
+++ b/test/tools/gendata
@@ -35,7 +35,7 @@ print("#ifndef _FFMS_TEST_".uc($arrayname)."_H\n");
 print("#define _FFMS_TEST_".uc($arrayname)."_H\n\n");
 print("#include \"data.h\"\n\n");
 
-for (`ffmpeg -i $filename -map $track:0 -f framehash - 2>/dev/null`) {
+for (`ffmpeg -i $filename -map $track:0 -enc_time_base -1 -f framehash - 2>/dev/null`) {
     if (/^#/) {
         if (!/^#tb/) {
             next;


### PR DESCRIPTION
Without this change, ffmpeg will choose a more appropriate timebase for the output. 
And in this case, the PTS/DTS in the genfile will be based on the new timebase which will not match the PTS we extract from the indexer.