### PR TITLE
Fix Keyframe Mismach Between Info and Frame

### DIFF
--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -402,7 +402,7 @@ void FFMS_Track::GeneratePublicInfo() {
             continue;
         RealFrameNumbers.push_back(static_cast<int>(i));
 
-        FFMS_FrameInfo info = { Frames[i].PTS, Frames[i].RepeatPict, Frames[Frames[i].OriginalPos].KeyFrame, Frames[i].OriginalPTS };
+        FFMS_FrameInfo info = { Frames[i].PTS, Frames[i].RepeatPict, Frames[i].KeyFrame, Frames[i].OriginalPTS };
         PublicFrameInfo.push_back(info);
     }
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -15,6 +15,7 @@ extern "C" {
 bool CheckFrame(const FFMS_Frame *Frame, const FFMS_FrameInfo *info, const TestFrameData *Data) {
     EQ_CHECK(info->PTS, Data->PTS);
     EQ_CHECK(!!info->KeyFrame, Data->Keyframe);
+    EQ_CHECK(!!Frame->KeyFrame, Data->Keyframe);
     EQ_CHECK(Frame->EncodedWidth, Data->Width);
     EQ_CHECK(Frame->EncodedHeight, Data->Height);
 


### PR DESCRIPTION
Should fix the keyframe mismach between `FFMS_FrameInfo` and `FFMS_Frame` in #333 discussion... not sure if it is correct, though.

@tgoyne @myrsloik maybe you remember why this used to only use OriginalPos for keyframe info? It doesn't seem right to me...

Of course, this *also* only seems to show up on edit list files... so it could be something completely different and this this **happens** to fix it. I'm a bit paranoid.

CC: @lotharkript