### PR TITLE
Allow building AviSynth plugin on non-Windows

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,13 @@ src_core_libffms2_la_SOURCES = \
 	src/vapoursynth/vapoursource.h \
 	src/vapoursynth/vapoursynth.cpp
 
+if AVISYNTH
+src_core_libffms2_la_SOURCES += \
+	src/avisynth/avssources.cpp \
+	src/avisynth/avssources.h \
+	src/avisynth/avisynth.cpp
+endif
+
 include_HEADERS = $(top_srcdir)/include/ffms.h $(top_srcdir)/include/ffmscompat.h
 
 bin_PROGRAMS = src/index/ffmsindex

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,16 @@ if test -z "$CXXFLAGS"; then
     CXXFLAGS="$OPT_FLAGS -Wall -Wextra"
 fi
 
+AC_ARG_ENABLE([avisynth],
+        [AC_HELP_STRING([--enable-avisynth],
+            [Enable AviSynth+ plugin. [default=no]])],
+        [enable_avisynth=yes],
+        [enable_avisynth=no]
+        )
+
+AC_MSG_RESULT([$enable_avisynth])
+AM_CONDITIONAL([AVISYNTH], [test "x$enable_avisynth" != "xno"])
+
 AC_CONFIG_HEADERS([src/config/config.h])
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,7 @@ if test "$enable_shared" = yes; then
         LDFLAGS="$LDFLAGS -Wl,-Bsymbolic"
         TEST_FFMPEG([bsymbolic])
         if test "$bsymbolic" = "yes"; then
-            src_core_libffms2_la_LDFLAGS="$src_core_libffms2_la_LDFLAGS -Wl-Bsymbolic"
+            src_core_libffms2_la_LDFLAGS="$src_core_libffms2_la_LDFLAGS -Wl,-Bsymbolic"
         else
             AC_MSG_RESULT($bsymbolic)
             AC_MSG_FAILURE([cannot build ffms2 as a shared library])

--- a/src/avisynth/avisynth.cpp
+++ b/src/avisynth/avisynth.cpp
@@ -23,6 +23,12 @@
 #include "avssources.h"
 #include "../core/utils.h"
 
+#ifdef _WIN32
+#define AVS_EXPORT __declspec(dllexport)
+#else
+#define AVS_EXPORT __attribute__((visibility("default")))
+#endif
+
 static AVSValue __cdecl CreateFFIndex(AVSValue Args, void* UserData, IScriptEnvironment* Env) {
     if (!Args[0].Defined())
         Env->ThrowError("FFIndex: No source specified");
@@ -336,7 +342,7 @@ static AVSValue __cdecl FFGetVersion(AVSValue Args, void* UserData, IScriptEnvir
 
 const AVS_Linkage *AVS_linkage = nullptr;
 
-extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScriptEnvironment* Env, const AVS_Linkage* const vectors) {
+extern "C" AVS_EXPORT const char* __stdcall AvisynthPluginInit3(IScriptEnvironment* Env, const AVS_Linkage* const vectors) {
     AVS_linkage = vectors;
 
     Env->AddFunction("FFIndex", "[source]s[cachefile]s[indexmask]i[errorhandling]i[overwrite]b", CreateFFIndex, nullptr);

--- a/src/avisynth/avssources.cpp
+++ b/src/avisynth/avssources.cpp
@@ -603,7 +603,7 @@ AvisynthAudioSource::~AvisynthAudioSource() {
     FFMS_DestroyAudioSource(A);
 }
 
-void AvisynthAudioSource::GetAudio(void* Buf, __int64 Start, __int64 Count, IScriptEnvironment *Env) {
+void AvisynthAudioSource::GetAudio(void* Buf, int64_t Start, int64_t Count, IScriptEnvironment *Env) {
     ErrorInfo E;
     if (FFMS_GetAudio(A, Buf, Start, Count, &E))
         Env->ThrowError("FFAudioSource: %s", E.Buffer);

--- a/src/avisynth/avssources.h
+++ b/src/avisynth/avssources.h
@@ -22,7 +22,9 @@
 #define FFAVSSOURCES_H
 
 #include <vector>
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include <avisynth.h>
 #include "ffms.h"
 
@@ -62,7 +64,7 @@ public:
     bool __stdcall GetParity(int n);
     int __stdcall SetCacheHints(int cachehints, int frame_range) { return 0; }
     const VideoInfo& __stdcall GetVideoInfo() { return VI; }
-    void __stdcall GetAudio(void* Buf, __int64 Start, __int64 Count, IScriptEnvironment *Env) {}
+    void __stdcall GetAudio(void* Buf, int64_t Start, int64_t Count, IScriptEnvironment *Env) {}
     PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment *Env);
 };
 
@@ -76,7 +78,7 @@ public:
     bool __stdcall GetParity(int n) { return false; }
     int __stdcall SetCacheHints(int cachehints, int frame_range) { return 0; }
     const VideoInfo& __stdcall GetVideoInfo() { return VI; }
-    void __stdcall GetAudio(void* Buf, __int64 Start, __int64 Count, IScriptEnvironment *Env);
+    void __stdcall GetAudio(void* Buf, int64_t Start, int64_t Count, IScriptEnvironment *Env);
     PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment *Env) { return nullptr; };
 };
 


### PR DESCRIPTION
AviSynth+ can be built and used on Linux, macOS, and BSD now.

I'm not sure if I did the hook in configure.ac correctly.  I just did what the enable_debug block does.

And tbh, I'm not crazy about just define-ing __int64 to int64_t instead of doing a proper move to stdint, but it was faster and less intrusive.  I can change that if so desired.

Partially related is that -Wl,-Bsymbolic wasn't being added even if configure detected that it needed to use it.  Just a missing comma, but that's fixed here too.