### PR TITLE
ParseVP9: Don't mark frames as invisible in newer versions of FFmpeg

### DIFF
--- a/src/core/videoutils.cpp
+++ b/src/core/videoutils.cpp
@@ -248,6 +248,7 @@ void ParseVP8(const uint8_t Buf, bool *Invisible, int *PictType) {
     *Invisible = (*Invisible || !(Buf & 0x10));
 }
 
+#if VERSION_CHECK(LIBAVCODEC_VERSION_INT, <, 58, 6, 102)
 void ParseVP9(const uint8_t Buf, bool *Invisible, int *PictType)
 {
     int profile = ((Buf & 0x20) >> 5) | ((Buf & 0x10) >> 3);
@@ -261,3 +262,15 @@ void ParseVP9(const uint8_t Buf, bool *Invisible, int *PictType)
         *Invisible = !(Buf & (0x2 >> shift));
     }
 }
+#else
+void ParseVP9(const uint8_t Buf, bool *Invisible, int *PictType)
+{
+    int profile = ((Buf & 0x20) >> 5) | ((Buf & 0x10) >> 3);
+    int shift = (profile == 3);
+
+    if (Buf & (0x8 >> shift))
+        *PictType = AV_PICTURE_TYPE_P;
+    else
+        *PictType = (Buf & (0x4 >> shift)) ? AV_PICTURE_TYPE_P : AV_PICTURE_TYPE_I;
+}
+#endif


### PR DESCRIPTION
They changed how superframes are retured, so in older versions, they are split, and you can get a packet that contains only an invisible frame, but in newer versions, they are not split, and marking a whole superframe as invisible is incorrect.

The version was not bumped for this breaking changed, of course,, so we choose the next, unrelated version bump to check for.

This is the non-broken part from #323, and can be merged while a full fix is pending.