### PR TITLE
videosource: Decode all packets, even if hidden, when the file is PAFF

### DIFF
--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -753,7 +753,7 @@ FFMS_Frame *FFMS_VideoSource::GetFrame(int n) {
 
         int64_t StartTime = AV_NOPTS_VALUE, FilePos = -1;
         bool Hidden = (((unsigned) CurrentFrame < Frames.size()) && Frames[CurrentFrame].Hidden);
-        if (HasSeeked || !Hidden)
+        if (HasSeeked || !Hidden || PAFFAdjusted)
             DecodeNextFrame(StartTime, FilePos);
 
         if (!HasSeeked)


### PR DESCRIPTION
Otherwise, we don't have enough packets to decode a frame until every 2nd call to GetFrame, and duplicates are output.

Not sure why I never upstreamed this.