### PR TITLE
ffmsindex: Allow adjustable progress update intervals 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,7 @@ include_HEADERS = $(top_srcdir)/include/ffms.h $(top_srcdir)/include/ffmscompat.
 
 bin_PROGRAMS = src/index/ffmsindex
 src_index_ffmsindex_SOURCES = src/index/ffmsindex.cpp
-src_index_ffmsindex_LDADD = src/core/libffms2.la
+src_index_ffmsindex_LDADD = src/core/libffms2.la @FFMPEG_LIBS@
 
 .PHONY: test test-build test-clean test-sync test-run
 clean-local: test-clean

--- a/src/index/ffmsindex.cpp
+++ b/src/index/ffmsindex.cpp
@@ -292,7 +292,7 @@ int main(int argc, const char *argv[]) {
 
         ParseCMDLine(argc, argv);
     } catch (Error const& e) {
-        std::cout << e.msg << std::endl;
+        std::cout << e.msg << std::endl << std::flush;
         return 1;
     }
 
@@ -309,7 +309,7 @@ int main(int argc, const char *argv[]) {
     try {
         DoIndexing();
     } catch (Error const& e) {
-        std::cout << e.msg << std::endl;
+        std::cout << e.msg << std::endl << std::flush;
         FFMS_Deinit();
         return 1;
     }

--- a/src/index/ffmsindex.cpp
+++ b/src/index/ffmsindex.cpp
@@ -35,6 +35,10 @@
 #include <string>
 #include <stdexcept>
 
+extern "C" {
+#include <libavutil/time.h>
+}
+
 namespace {
 
 long long IndexMask = 0;
@@ -46,6 +50,7 @@ bool WriteTC = false;
 bool WriteKF = false;
 bool EnableDrefs = false;
 bool UseAbsolutePath = false;
+int64_t ProgressInterval = 1000000; // One second
 std::string InputFile;
 std::string CacheFile;
 
@@ -55,6 +60,11 @@ struct Error {
     Error(const char *msg, FFMS_ErrorInfo const& e) : msg(msg) {
         this->msg.append(e.Buffer);
     }
+};
+
+struct Progress {
+    int Percent;
+    int64_t Time;
 };
 
 void PrintUsage() {
@@ -71,11 +81,18 @@ void PrintUsage() {
         "-k        Write keyframes for all video tracks to outputfile_track00.kf.txt (default: no)\n"
         "-t N      Set the audio indexing mask to N (-1 means index all tracks, 0 means index none, default: 0)\n"
         "-s N      Set audio decoding error handling. See the documentation for details. (default: 0)\n"
+        "-u N      Set the progress update frequency in seconds. Set to 0 for every percent. (default: 1)\n"
         "\n"
         "FFmpeg Demuxer Options:\n"
         "--enable_drefs\n"
         "--use_absolute_path\n"
         << std::endl;
+}
+
+int64_t parseSecondsToMicroseconds(const char *str) {
+    double val = std::strtod(str, nullptr);
+    int64_t ret = (int64_t) (val * 1000000.0);
+    return ret;
 }
 
 void ParseCMDLine(int argc, const char *argv[]) {
@@ -97,6 +114,8 @@ void ParseCMDLine(int argc, const char *argv[]) {
             OPTION_ARG(IndexMask, "t", std::stoll);
         } else if (!strcmp(Option, "-s")) {
             OPTION_ARG(IgnoreErrors, "s", std::stoi);
+        } else if (!strcmp(Option, "-u")) {
+            OPTION_ARG(ProgressInterval, "u", parseSecondsToMicroseconds);
         } else if (!strcmp(Option, "--enable_drefs")) {
             EnableDrefs = true;
         } else if (!strcmp(Option, "--use_absolute_path")) {
@@ -128,10 +147,12 @@ int FFMS_CC UpdateProgress(int64_t Current, int64_t Total, void *Private) {
     int Percentage = int((double(Current) / double(Total)) * 100);
 
     if (Private) {
-        int *LastPercentage = (int *)Private;
-        if (Percentage <= *LastPercentage)
+        Progress *LastProgress = (Progress *)Private;
+        int64_t CurTime = av_gettime();
+        if (Percentage <= LastProgress->Percent || (LastProgress->Time != 0 && (CurTime - LastProgress->Time) <= ProgressInterval))
             return 0;
-        *LastPercentage = Percentage;
+        LastProgress->Percent = Percentage;
+        LastProgress->Time = CurTime;
     }
 
     std::cout << "Indexing, please wait... " << Percentage << "% \r" << std::flush;
@@ -154,7 +175,7 @@ void DoIndexing() {
     E.Buffer = ErrorMsg;
     E.BufferSize = sizeof(ErrorMsg);
 
-    int Progress = 0;
+    Progress ProgressTracker = { 0, av_gettime() };
 
     FFMS_Index *Index = FFMS_ReadIndex(CacheFile.c_str(), &E);
     if (Index) {
@@ -171,7 +192,7 @@ void DoIndexing() {
     if (Indexer == nullptr)
         throw Error("\nFailed to initialize indexing: ", E);
 
-    FFMS_SetProgressCallback(Indexer, UpdateProgress, &Progress);
+    FFMS_SetProgressCallback(Indexer, UpdateProgress, &ProgressTracker);
 
     // Treat -1 as meaning track numbers above sizeof(long long) * 8 too, dumping implies indexing
     if (IndexMask == -1)


### PR DESCRIPTION
Default is 1 second.

This also adds some missing `std::flush`.