### PR TITLE
FFMS_Frame: Pass through Dolby Vision RPU side data

### DIFF
--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((3 << 24) | (0 << 16) | (0 << 8) | 0)
+#define FFMS_VERSION ((3 << 24) | (0 << 16) | (1 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -338,6 +338,9 @@ typedef struct FFMS_Frame {
     int HasContentLightLevel; /* Non-zero if the 2 fields below are valid */
     unsigned int ContentLightLevelMax;
     unsigned int ContentLightLevelAverage;
+    /* Introduced in FFMS_VERSION ((3 << 24) | (0 << 16) | (1 << 8) | 0) */
+    uint8_t *DolbyVisionRPU;
+    int DolbyVisionRPUSize;
 } FFMS_Frame;
 
 typedef struct FFMS_TrackTimeBase {

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -77,6 +77,8 @@ private:
 
     FFMS_VideoProperties VP = {};
     FFMS_Frame LocalFrame = {};
+    uint8_t *RPUBuffer = nullptr;
+    size_t RPUBufferSize = 0;
     AVFrame *DecodeFrame = nullptr;
     AVFrame *LastDecodedFrame = nullptr;
     int LastFrameNum = 0;


### PR DESCRIPTION
I put this under version guards rather than bump the minimum FFmpeg version because I literally pushed this to FFmpeg master today.