### PR TITLE
vapoursource: Set Dolby Vision RPU data in frame props

### DIFF
--- a/src/vapoursynth/vapoursource.cpp
+++ b/src/vapoursynth/vapoursource.cpp
@@ -204,6 +204,10 @@ const VSFrameRef *VS_CC VSVideoSource::GetFrame(int n, int activationReason, voi
             vsapi->propSetFloat(Props, "ContentLightLevelAverage", Frame->ContentLightLevelAverage, paReplace);
         }
 
+        if (Frame->DolbyVisionRPU && Frame->DolbyVisionRPUSize) {
+            vsapi->propSetData(Props, "DolbyVisionRPU", (const char *) Frame->DolbyVisionRPU, Frame->DolbyVisionRPUSize, paReplace);
+        }
+
         const FFMS_VideoProperties *VP = FFMS_GetVideoProperties(vs->V);
         vsapi->propSetInt(Props, "Flip", VP->Flip, paReplace);
         vsapi->propSetInt(Props, "Rotation", VP->Rotation, paReplace);

--- a/src/vapoursynth/vapoursource4.cpp
+++ b/src/vapoursynth/vapoursource4.cpp
@@ -191,6 +191,9 @@ const VSFrame *VS_CC VSVideoSource4::GetVSFrame(int n, VSCore *core, const VSAPI
         vsapi->mapSetFloat(Props, "ContentLightLevelAverage", Frame->ContentLightLevelAverage, maReplace);
     }
 
+    if (Frame->DolbyVisionRPU && Frame->DolbyVisionRPUSize) {
+        vsapi->mapSetData(Props, "DolbyVisionRPU", (const char *) Frame->DolbyVisionRPU, Frame->DolbyVisionRPUSize, dtBinary, maReplace);
+    }
 
     OutputFrame(Frame, Dst, vsapi);
     if (OutputAlpha) {


### PR DESCRIPTION
Normally as the RPU added in https://github.com/FFMS/ffms2/pull/396 is guarded, this has no downside.
Tested with some WIP code here: https://github.com/quietvoid/vs-placebo/blob/6bed053c32f132e477e20bd074199a31465b7c51/tonemap.c#L223

It works fine for me.

I've tested with setting an int prop to the pointer, but it does not work consistently.
Or maybe I didn't cast things properly.