### PR TITLE
videosource: Only apply PAFF adjustment if the frame is marked as interlaced

### DIFF
--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -629,7 +629,7 @@ bool FFMS_VideoSource::DecodePacket(AVPacket *Packet) {
     // H.264 (PAFF) and HEVC can have one field per packet, and decoding delay needs
     // to be adjusted accordingly.
     if (CodecContext->codec_id == AV_CODEC_ID_H264 || CodecContext->codec_id == AV_CODEC_ID_HEVC) {
-        if (!PAFFAdjusted && DelayCounter > Delay && LastDecodedFrame->repeat_pict == 0 && Ret != 0) {
+        if (!PAFFAdjusted && DelayCounter > Delay && LastDecodedFrame->interlaced_frame == 1 && LastDecodedFrame->repeat_pict == 0 && Ret != 0) {
             int OldBFrameDelay = Delay - (CodecContext->thread_count - 1);
             Delay = 1 + OldBFrameDelay * 2 + (CodecContext->thread_count - 1);
             PAFFAdjusted = true;


### PR DESCRIPTION
Otherwise seeking can be jank in certain types of streams like open GOP HEVC or MP4s with huge edit list trims a the very start.

Fixes #394.