### PR TITLE
VideoSource: Fix PAFF detection

### DIFF
--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -629,7 +629,9 @@ bool FFMS_VideoSource::DecodePacket(AVPacket *Packet) {
     // H.264 (PAFF) and HEVC can have one field per packet, and decoding delay needs
     // to be adjusted accordingly.
     if (CodecContext->codec_id == AV_CODEC_ID_H264 || CodecContext->codec_id == AV_CODEC_ID_HEVC) {
-        if (!PAFFAdjusted && DelayCounter > Delay && LastDecodedFrame->interlaced_frame == 1 && LastDecodedFrame->repeat_pict == 0 && Ret != 0) {
+        if (LastDecodedFrame->interlaced_frame == 1)
+            HaveSeenInterlacedFrame = true;
+        if (!PAFFAdjusted && DelayCounter > Delay && HaveSeenInterlacedFrame && LastDecodedFrame->repeat_pict == 0 && Ret != 0) {
             int OldBFrameDelay = Delay - (CodecContext->thread_count - 1);
             Delay = 1 + OldBFrameDelay * 2 + (CodecContext->thread_count - 1);
             PAFFAdjusted = true;

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -92,6 +92,7 @@ private:
     int SeekMode;
     bool SeekByPos = false;
     int PosOffset = 0;
+    bool HaveSeenInterlacedFrame = false;
 
     void ReAdjustOutputFormat(AVFrame *Frame);
     FFMS_Frame *OutputFrame(AVFrame *Frame);


### PR DESCRIPTION
Depending on the packet and field order, the packet which violates the delay may or may not be marked as interlaced. To 'solve' this, detect if we've ever seen an interlaced frame before.

This was broken in ff61bca13e2c5fb99c0450620c9244f415ec29c4.