### PR TITLE
Set permissions for Github Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Closes #411 

### Changes
- ci.yml: top level permission set as contents read. Example of workflow running after change https://github.com/joycebrum/ffms2/actions/runs/4265863980