### PR TITLE
Create a Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/FFMS/ffms2/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Closes #416 

I've created the SECURITY.md file considering the [report vulnerability through security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which is a new github feature still in beta and that has to be enabled.

If you're interested in GitHub's feature, it must be activated for the repository:
1. Open the repo's settings
2. Click on [Code security & analysis](https://github.com/FFMS/ffms2/settings/security_analysis)
3. Click "Enable" for "Private vulnerability reporting (Beta)"

If you rather not enable it there is also the possibility to receive the vulnerability report through an email, in this case just let me know which email it would be and I'll submit the change.

Besides that, feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.
