### PR TITLE
Hard fail on IO error during indexing and decode

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -140,3 +140,25 @@ bool IsSamePath(const char *p1, const char *p2) {
     return !_stricmp(p1, p2);
 #endif
 }
+
+bool IsIOError(int error) {
+    switch (error) {
+    case AVERROR(EIO):
+    case AVERROR(ETIMEDOUT):
+    case AVERROR(EPROTO):
+    case AVERROR(EADDRINUSE):
+    case AVERROR(EADDRNOTAVAIL):
+    case AVERROR(ENETDOWN):
+    case AVERROR(ENETUNREACH):
+    case AVERROR(ENETRESET):
+    case AVERROR(ECONNABORTED):
+    case AVERROR(ECONNRESET):
+    case AVERROR(ESHUTDOWN):
+    case AVERROR(ECONNREFUSED):
+    case AVERROR(EHOSTDOWN):
+    case AVERROR(EHOSTUNREACH):
+        return true;
+    default:
+        return false;
+    }
+}

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -134,5 +134,6 @@ void SetOptions(T const& src, void *opt, OptionMapper<T>(&options)[N]) {
 
 int ResizerNameToSWSResizer(const char *ResizerName);
 bool IsSamePath(const char *p1, const char *p2);
+bool IsIOError(int error);
 
 #endif


### PR DESCRIPTION
If we encounter an IO error while reading packets, we don't want the current behavior of just ending the indexing or decoding here and treating the file as truncated - we want to hard fail so it is apparent there has been an IO issue.

This is helpful in e.g. networked situations.

# Note

We ($dayjob) have been using a patch similar to this internally for quite a while, so it should be pretty resilient. I finally got around to cleaning it up for submission here.