### PR TITLE
ffmsindex: Allow demuxer options to be set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,7 @@ include_HEADERS = $(top_srcdir)/include/ffms.h $(top_srcdir)/include/ffmscompat.
 
 bin_PROGRAMS = src/index/ffmsindex
 src_index_ffmsindex_SOURCES = src/index/ffmsindex.cpp
-src_index_ffmsindex_LDADD = src/core/libffms2.la
+src_index_ffmsindex_LDADD = -lavutil src/core/libffms2.la
 
 .PHONY: test test-build test-clean test-sync test-run
 clean-local: test-clean


### PR DESCRIPTION
# Notes

AFAICT there's not really a sane way to split strings using the C++ STL, but maybe I am mistaken.

Also, I think the Visual C++ projects would need to be updated to link ffmsindex to libavutil? I dont have a Windows dev env, myself.