### PR TITLE
Various fixes to seeking and decoding

### DIFF
--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -71,6 +71,10 @@ void FFMS_Index::Finalize(std::vector<SharedAVContext> const& video_contexts, co
     for (size_t i = 0, end = size(); i != end; ++i) {
         FFMS_Track& track = (*this)[i];
 
+        if (!strcmp(Format, "mpeg") || !strcmp(Format, "mpegts") || !strcmp(Format, "mpegtsraw"))
+            if (std::any_of(track.begin(), track.end(), [](FrameInfo F) { return F.PTS == AV_NOPTS_VALUE; }))
+                track.RevertToDTS();
+
         // Some audio tracks are simply insane junk (seen with als) and will have a single(?) super long packet and
         // apart from that look legit and be chosen instead of usable audio. This hopefully rejects some of it.
         // Caused by sample in https://github.com/FFMS/ffms2/issues/351
@@ -85,6 +89,7 @@ void FFMS_Index::Finalize(std::vector<SharedAVContext> const& video_contexts, co
         // but may also have valid, split packets, with pos equal to the previous pos.
         if (video_contexts[i].CodecContext && video_contexts[i].CodecContext->codec_id == AV_CODEC_ID_H264 && !!strcmp(Format, "asf"))
             track.MaybeHideFrames();
+
         track.FinalizeTrack();
 
         if (track.TT != FFMS_TYPE_VIDEO) continue;
@@ -430,7 +435,8 @@ FFMS_Index *FFMS_Indexer::DoIndexing() {
     std::vector<SharedAVContext> AVContexts(FormatContext->nb_streams);
 
     auto TrackIndices = std::unique_ptr<FFMS_Index>(new FFMS_Index(Filesize, Digest, ErrorHandling, LAVFOpts));
-    bool UseDTS = !strcmp(FormatContext->iformat->name, "mpeg") || !strcmp(FormatContext->iformat->name, "mpegts") || !strcmp(FormatContext->iformat->name, "mpegtsraw") || !strcmp(FormatContext->iformat->name, "nuv");
+    bool UseDTS = !strcmp(FormatContext->iformat->name, "nuv");
+    bool IsMpegLike = !strcmp(FormatContext->iformat->name, "mpeg") || !strcmp(FormatContext->iformat->name, "mpegts") || !strcmp(FormatContext->iformat->name, "mpegtsraw");
 
     for (unsigned int i = 0; i < FormatContext->nb_streams; i++) {
         TrackIndices->emplace_back((int64_t)FormatContext->streams[i]->time_base.num * 1000,
@@ -527,7 +533,7 @@ FFMS_Index *FFMS_Indexer::DoIndexing() {
 
         if (FormatContext->streams[Track]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
             int64_t PTS = TrackInfo.UseDTS ? Packet->dts : Packet->pts;
-            if (PTS == AV_NOPTS_VALUE) {
+            if (PTS == AV_NOPTS_VALUE && !IsMpegLike) {
                 // VPx alt-refs are output as packets which lack timestmps or durations, since
                 // they are invisible. Currently, the timestamp mangling code in libavformat
                 // will sometimes add a bogus timestamp and duration, if the webm in question
@@ -558,7 +564,7 @@ FFMS_Index *FFMS_Indexer::DoIndexing() {
             bool SecondField = false;
             ParseVideoPacket(AVContexts[Track], Packet, &RepeatPict, &FrameType, &Invisible, &SecondField, &LastPicStruct);
 
-            TrackInfo.AddVideoFrame(PTS, RepeatPict, KeyFrame,
+            TrackInfo.AddVideoFrame(PTS, Packet->dts, RepeatPict, KeyFrame,
                 FrameType, Packet->pos, Invisible, SecondField);
         } else if (FormatContext->streams[Track]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
             // For video seeking timestamps are used only if all packets have
@@ -571,7 +577,7 @@ FFMS_Index *FFMS_Indexer::DoIndexing() {
             uint32_t SampleCount = IndexAudioPacket(Track, Packet, AVContexts[Track], *TrackIndices);
             TrackInfo.SampleRate = AVContexts[Track].CodecContext->sample_rate;
 
-            TrackInfo.AddAudioFrame(LastValidTS[Track],
+            TrackInfo.AddAudioFrame(LastValidTS[Track], Packet->dts,
                 StartSample, SampleCount, KeyFrame, Packet->pos, Packet->flags & AV_PKT_FLAG_DISCARD);
         }
 

--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -85,7 +85,7 @@ private:
     void ReadTS(const AVPacket *Packet, int64_t &TS, bool &UseDTS);
     void CheckAudioProperties(int Track, AVCodecContext *Context);
     uint32_t IndexAudioPacket(int Track, AVPacket *Packet, SharedAVContext &Context, FFMS_Index &TrackIndices);
-    void ParseVideoPacket(SharedAVContext &VideoContext, AVPacket *pkt, int *RepeatPict, int *FrameType, bool *Invisible, enum AVPictureStructure *LastPicStruct);
+    void ParseVideoPacket(SharedAVContext &VideoContext, AVPacket *pkt, int *RepeatPict, int *FrameType, bool *Invisible, bool *SecondField, enum AVPictureStructure *LastPicStruct);
     void Free();
 public:
     FFMS_Indexer(const char *Filename, const FFMS_KeyValuePair *DemuxerOptions, int NumOptions);

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -161,12 +161,12 @@ static bool PTSComparison(FrameInfo FI1, FrameInfo FI2) {
     return FI1.PTS < FI2.PTS;
 }
 
-int FFMS_Track::FrameFromPTS(int64_t PTS) const {
+int FFMS_Track::FrameFromPTS(int64_t PTS, bool AllowHidden) const {
     FrameInfo F;
     F.PTS = PTS;
 
     auto Pos = std::lower_bound(begin(), end(), F, PTSComparison);
-    while (Pos != end() && Pos->Hidden && Pos->PTS == PTS)
+    while (Pos != end() && (!AllowHidden && Pos->Hidden) && Pos->PTS == PTS)
         Pos++;
 
     if (Pos == end() || Pos->PTS != PTS)
@@ -174,9 +174,9 @@ int FFMS_Track::FrameFromPTS(int64_t PTS) const {
     return std::distance(begin(), Pos);
 }
 
-int FFMS_Track::FrameFromPos(int64_t Pos) const {
+int FFMS_Track::FrameFromPos(int64_t Pos, bool AllowHidden) const {
     for (size_t i = 0; i < size(); i++)
-        if (Data->Frames[i].FilePos == Pos && !Data->Frames[i].Hidden)
+        if (Data->Frames[i].FilePos == Pos && (AllowHidden || !Data->Frames[i].Hidden))
             return static_cast<int>(i);
     return -1;
 }

--- a/src/core/track.h
+++ b/src/core/track.h
@@ -40,7 +40,11 @@ struct FrameInfo {
     int FrameType;
     int RepeatPict;
     bool KeyFrame;
-    bool Hidden;
+    bool MarkedHidden;
+    bool SecondField;
+
+    // If true, no frame corresponding to this packet will be output
+    constexpr bool Skipped() const { return MarkedHidden || SecondField; }
 };
 
 struct FFMS_Track {
@@ -67,7 +71,7 @@ public:
     int64_t LastDuration = 0;
     int SampleRate = 0; // not persisted
 
-    void AddVideoFrame(int64_t PTS, int RepeatPict, bool KeyFrame, int FrameType, int64_t FilePos = 0, bool Invisible = false);
+    void AddVideoFrame(int64_t PTS, int RepeatPict, bool KeyFrame, int FrameType, int64_t FilePos = 0, bool Invisible = false, bool SecondField = false);
     void AddAudioFrame(int64_t PTS, int64_t SampleStart, uint32_t SampleCount, bool KeyFrame, int64_t FilePos = 0, bool Invisible = false);
 
     void MaybeHideFrames();

--- a/src/core/track.h
+++ b/src/core/track.h
@@ -43,6 +43,8 @@ struct FrameInfo {
     bool MarkedHidden;
     bool SecondField;
 
+    int64_t DTS;        // Only used during indexing and not stored in the index file. (If UseDTS is true, the PTS values will be DTS)
+
     // If true, no frame corresponding to this packet will be output
     constexpr bool Skipped() const { return MarkedHidden || SecondField; }
 };
@@ -71,9 +73,10 @@ public:
     int64_t LastDuration = 0;
     int SampleRate = 0; // not persisted
 
-    void AddVideoFrame(int64_t PTS, int RepeatPict, bool KeyFrame, int FrameType, int64_t FilePos = 0, bool Invisible = false, bool SecondField = false);
-    void AddAudioFrame(int64_t PTS, int64_t SampleStart, uint32_t SampleCount, bool KeyFrame, int64_t FilePos = 0, bool Invisible = false);
+    void AddVideoFrame(int64_t PTS, int64_t DTS, int RepeatPict, bool KeyFrame, int FrameType, int64_t FilePos = 0, bool Invisible = false, bool SecondField = false);
+    void AddAudioFrame(int64_t PTS, int64_t DTS, int64_t SampleStart, uint32_t SampleCount, bool KeyFrame, int64_t FilePos = 0, bool Invisible = false);
 
+    void RevertToDTS();
     void MaybeHideFrames();
     void FinalizeTrack();
     void FillAudioGaps();

--- a/src/core/track.h
+++ b/src/core/track.h
@@ -75,8 +75,8 @@ public:
     void FillAudioGaps();
 
     int FindClosestVideoKeyFrame(int Frame) const;
-    int FrameFromPTS(int64_t PTS) const;
-    int FrameFromPos(int64_t Pos) const;
+    int FrameFromPTS(int64_t PTS, bool AllowHidden = false) const;
+    int FrameFromPos(int64_t Pos, bool AllowHidden = false) const;
     int ClosestFrameFromPTS(int64_t PTS) const;
     int RealFrameNumber(int Frame) const;
     int VisibleFrameCount() const;

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -931,10 +931,16 @@ FFMS_Frame *FFMS_VideoSource::GetFrame(int n) {
         // aggressive (non-keyframe) seeking.
         int64_t Pos = Frames[CurrentFrame].FilePos;
         if (CurrentFrame > 0 && Pos != -1) {
-            int Prev = CurrentFrame - 1;
-            while (Prev >= 0 && Frames[Prev].FilePos != -1 && Frames[Prev].FilePos > Pos)
-                --Prev;
-            CurrentFrame = Prev + 1;
+            while (true) {
+                int Prev = CurrentFrame - 1;
+                if (Prev >= 0 && Frames[Prev].SecondField)
+                    --Prev;
+
+                if (Prev >= 0 && (Frames[Prev].FilePos != -1 && Frames[Prev].FilePos > Pos))
+                    CurrentFrame = Prev;
+                else
+                    break;
+            }
         }
 
         if (Frames[CurrentFrame].Skipped()) {

--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -279,6 +279,8 @@ FFMS_VideoSource::FFMS_VideoSource(const char *SourceFile, FFMS_Index &Index, in
                 Delay.ThreadDelay = CodecContext->thread_count - 1;
         }
 
+        SeekByPos = !strcmp(FormatContext->iformat->name, "mpeg") || !strcmp(FormatContext->iformat->name, "mpegts") || !strcmp(FormatContext->iformat->name, "mpegtsraw");
+
         // Always try to decode a frame to make sure all required parameters are known
         int64_t DummyPTS = 0, DummyPos = 0;
         DecodeNextFrame(DummyPTS, DummyPos);

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -45,12 +45,24 @@ enum class DecodeStage {
     DECODE_LOOP,
 };
 
+struct DecoderDelay {
+    int ThreadDelay = 0;
+    int ReorderDelay = 0;
+
+    int ThreadDelayCounter = 0;
+    int ReorderDelayCounter = 0;
+
+    void Reset();
+    void Increment(bool Hidden, bool SecondField);
+    void Decrement();
+    bool IsExceeded();
+};
+
 struct FFMS_VideoSource {
 private:
     SwsContext *SWS = nullptr;
 
-    int Delay = 0;
-    int DelayCounter = 0;
+    DecoderDelay Delay;
     DecodeStage Stage = DecodeStage::INITIALIZE;
 
     int LastFrameHeight = -1;

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -40,6 +40,7 @@ extern "C" {
 #include "utils.h"
 
 enum class DecodeStage {
+    INITIALIZE_SOURCE,
     INITIALIZE,
     APPLY_DELAY,
     DECODE_LOOP,
@@ -63,7 +64,7 @@ private:
     SwsContext *SWS = nullptr;
 
     DecoderDelay Delay;
-    DecodeStage Stage = DecodeStage::INITIALIZE;
+    DecodeStage Stage = DecodeStage::INITIALIZE_SOURCE;
 
     int LastFrameHeight = -1;
     int LastFrameWidth = -1;

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -52,7 +52,6 @@ private:
     int Delay = 0;
     int DelayCounter = 0;
     DecodeStage Stage = DecodeStage::INITIALIZE;
-    bool PAFFAdjusted = false;
 
     int LastFrameHeight = -1;
     int LastFrameWidth = -1;


### PR DESCRIPTION
This consists of various bigger refactors which were necessary to fix certain parts of seeking, but it can still mostly be read commit for commit. Some of the later commits do make some of the earlier commits partially obsolete, so let me know if you'd like any of this squashed.

I sent a patch to ffmpeg to fix 70a7c1b619105fcc6bf4ff77cc4ea34853651cd9 but didn't get a response yet.

Running seek tests with this on the [doom9 sample file collection](https://drive.google.com/file/d/1-95lSEnxu3aGZS3WqwJPaYHSk4M7GSr9/view) shows no regressions:
Before (the format being `filename,number of errors`):
```
00006.mkv,0
132518447-659caa63-ce2d-4120-9f76-5700cfc7fcb6.mov,0
3d-parrot.mkv,546
3d-parrot.MTS,547
amarec(20200806-1406)_sample.avi,0
apple_trailers.mov,0
a_test.mkv,0
AV1 Summer.webm,0
AVC ES.264,0
avidv.avi,0
bars601.mkv,0
bars601.ts,224
batman.v.superman.mkv,0
BD 21 grammi.mkv,0
BoatsAtLahaina_too_few_timecodes.mp4,0
camcorder_25i_4-3.mkv,0
CANON.MXF,0
Chimera-AV1-10bit-1280x720-2380kbps.mp4,0
crowd-x265.mp4,0
dvd.mkv,0
dvd.mpeg,0
ffms2_seeking_issue.mkv,0
ffms2_seeking_issue.mp4,224
flpyoj.mkv,0
h263.3gp,0
interlaced_h264.mkv,139
interlaced_h264.mp4,196
Letter - SHE'S.mkv,0
MainconceptLogo_Blu-ray_MPEG2_1920x1080_LPCM.mkv,0
MainconceptLogo_Blu-ray_MPEG2_1920x1080_LPCM.mpg,28
MainconceptLogo_MPEG2_DVD_720x576.mkv,0
MainconceptLogo_MPEG2_DVD_720x576.mpg,88
MC TMB.mov,0
mpeg1.mov,Error
mpeg1.mpg,155
MPEGSolution_stuart.mkv,0
MPEGSolution_stuart.mp4,8634
Nagi no Asukara 2013 - EP01 [BD 1920x1080 23.976fps AVC-yuv444p10 FLACx3 Chap] - mawen1250.mkv,0
NTSC_720p_MPEG_XDCAM-EX_colorbar.mxf,0
parkrun1280_12mbps.mkv,0
parkrun1280_12mbps.ts,473
rav1e_b_4600.ivf,0
rav1e_q_150.mkv,0
seek-test.mkv,0
snow.MTS,437
Sunset.m2ts,0
Sunset.mkv,0
VC1.mpg,98
vc1_sample.mkv,579
VP9.mkv,0
VTS_01_1.demuxed.m2v,0
yVY.webm,0
Zenit.mkv,4487
```

After: (Don't pay too close attention to the actual numbers, for this second seek test I had to clip all videos to 200 frames to make the tests faster. What's important is the presence or absence of errors. If necessary I can also run a full seek test, though.)
```
00006.mkv,0
132518447-659caa63-ce2d-4120-9f76-5700cfc7fcb6.mov,0
3d-parrot.mkv,0
3d-parrot.MTS,50
amarec(20200806-1406)_sample.avi,0
apple_trailers.mov,0
a_test.mkv,0
AV1 Summer.webm,0
AVC ES.264,0
avidv.avi,0
bars601.mkv,0
bars601.ts,41
batman.v.superman.mkv,0
BD 21 grammi.mkv,0
BoatsAtLahaina_too_few_timecodes.mp4,0
camcorder_25i_4-3.mkv,0
CANON.MXF,0
Chimera-AV1-10bit-1280x720-2380kbps.mp4,0
crowd-x265.mp4,0
dvd.mkv,0
dvd.mpeg,0
ffms2_seeking_issue.mkv,0
ffms2_seeking_issue.mp4,0
flpyoj.mkv,0
h263.3gp,0
interlaced_h264.mkv,0
interlaced_h264.mp4,0
Letter - SHE'S.mkv,0
MainconceptLogo_Blu-ray_MPEG2_1920x1080_LPCM.mkv,0
MainconceptLogo_Blu-ray_MPEG2_1920x1080_LPCM.mpg,20
MainconceptLogo_MPEG2_DVD_720x576.mkv,0
MainconceptLogo_MPEG2_DVD_720x576.mpg,84
MC TMB.mov,0
mpeg1.mov,Error
mpeg1.mpg,125
MPEGSolution_stuart.mkv,0
MPEGSolution_stuart.mp4,374
Nagi no Asukara 2013 - EP01 [BD 1920x1080 23.976fps AVC-yuv444p10 FLACx3 Chap] - mawen1250.mkv,0
NTSC_720p_MPEG_XDCAM-EX_colorbar.mxf,0
parkrun1280_12mbps.mkv,0
parkrun1280_12mbps.ts,41
rav1e_b_4600.ivf,0
rav1e_q_150.mkv,0
seek-test.mkv,0
snow.MTS,1
Sunset.m2ts,0
Sunset.mkv,0
VC1.mpg,242
vc1_sample.mkv,47
VP9.mkv,0
VTS_01_1.demuxed.m2v,0
yVY.webm,0
Zenit.mkv,0
```

Some background on some specific files affected by this PR:
- `3d-parrot.mkv` is an interlaced open-gop h264 file
- `interlaced_h264.mkv` is an interlaced open-gop h264 file that uses MBAFF and hence still has one packet per frame.
- `ffms2_seeking_issue.mp4` is a progressive open-gop h264 file that has been cut at a non-IDR recovery point (and hence doesn't start with an IDR frame), where frames 1 and 2 (starting at 0) in decoding order rely on missing references, are marked as hidden by the demuxer, and are skipped by the decoder.

So after this PR all mkv and mp4 files have consistent seeking, except for:
- the VC-1 file: VC-1 demuxing seems very broken in ffmpeg (for example every single packet is marked as a keyframe)
- `MPEGSolution_stuart.mp4`, which seems to just be a broken file that also corrupts in players like mpv.