### PR TITLE
Multilayer Decoding Support (and minimum FFmpeg version bump)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ PKG_PROG_PKG_CONFIG([0.22])
 pkgconfigdir="\$(libdir)/pkgconfig"
 AC_SUBST(pkgconfigdir)
 
-PKG_CHECK_MODULES(FFMPEG, [libavformat >= 60.16.0 libavcodec >= 60.31.0 libswscale >= 7.5.0 libavutil >= 58.29.0 libswresample >= 4.12.0])
+PKG_CHECK_MODULES(FFMPEG, [libavformat >= 61.7.0 libavcodec >= 61.19.0 libswscale >= 8.3.0 libavutil >= 59.39.0 libswresample >= 5.3.0])
 
 dnl As of 0eec06ed8747923faa6a98e474f224d922dc487d ffmpeg only adds -lrt to lavc's
 dnl LIBS, but lavu needs it, so move it to the end if it's present

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE([1.11 subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])
 
-VERSION_INFO="5:0:0"
+VERSION_INFO="5:1:0"
 
 AC_MSG_CHECKING([if debug build is enabled])
 

--- a/doc/ffms2-changelog.md
+++ b/doc/ffms2-changelog.md
@@ -1,4 +1,7 @@
 # FFmpegSource2 Changelog
+- 5.1
+  - FFmpeg 7.1 is now the minimum requirement.
+
 - 5.0
   - Fixed all issues with FFmpeg 6.1 which is now the minimum requirement
   - Fixed av1 decoding

--- a/doc/ffms2-changelog.md
+++ b/doc/ffms2-changelog.md
@@ -1,6 +1,7 @@
 # FFmpegSource2 Changelog
 - 5.1
   - FFmpeg 7.1 is now the minimum requirement.
+  - Added layered decoding support, for e.g. spatial MV-HEVC.
 
 - 5.0
   - Fixed all issues with FFmpeg 6.1 which is now the minimum requirement

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((5 << 24) | (0 << 16) | (0 << 8) | 0)
+#define FFMS_VERSION ((5 << 24) | (1 << 16) | (0 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -344,6 +344,18 @@ typedef struct FFMS_Frame {
     /* Introduced in FFMS_VERSION ((3 << 24) | (1 << 16) | (1 << 8) | 0) */
     uint8_t *HDR10Plus;
     int HDR10PlusSize;
+
+    /*
+     * If these buffers are not NULL, left and right eye data is present.
+     * In such a case, the main buffer points to the primary eye's buffer,
+     * for use in monoscopic encoding.
+     *
+     * Introduced in FFMS_VERSION ((5 << 24) | (1 << 16) | (0 << 8) | 0)
+     */
+    const uint8_t *LeftEyeData[4];
+    int LeftEyeLinesize[4];
+    const uint8_t *RightEyeData[4];
+    int RightEyeLinesize[4];
 } FFMS_Frame;
 
 typedef struct FFMS_TrackTimeBase {

--- a/src/core/videosource.h
+++ b/src/core/videosource.h
@@ -92,6 +92,12 @@ private:
 
     uint8_t *SWSFrameData[4] = {};
     int SWSFrameLinesize[4] = {};
+    bool EyesInverted = false;
+    bool PrimaryEyeIsLeft = true;
+    uint8_t *LeftEyeFrameData[4] = {};
+    int LeftEyeLinesize[4] = {};
+    uint8_t *RightEyeFrameData[4] = {};
+    int RightEyeLinesize[4] = {};
 
     AVPacket *StashedPacket = nullptr;
     bool ResendPacket = false;
@@ -118,6 +124,7 @@ private:
     int SeekMode;
     bool SeekByPos = false;
     bool HaveSeenInterlacedFrame = false;
+    bool IsLayered = false;
 
     void ReAdjustOutputFormat(AVFrame *Frame);
     FFMS_Frame *OutputFrame(AVFrame *Frame);
@@ -135,6 +142,7 @@ public:
     FFMS_Track *GetTrack() { return &Frames; }
     FFMS_Frame *GetFrame(int n);
     void GetFrameCheck(int n);
+    void CopyEye(AVStereo3DView view);
     FFMS_Frame *GetFrameByTime(double Time);
     void SetOutputFormat(const AVPixelFormat *TargetFormats, int Width, int Height, int Resizer);
     void ResetOutputFormat();


### PR DESCRIPTION
This brings in support for decoding multi-layer video - mainly Vision Pro spatial MV-HEVC files. Only two eyes are supported.

Please comment on the API if needed.

Likely needs some refactoring, especially the inner loop.

I was lazy, so rather than doing compat stuff, I made the latest release of FFmpeg (7.1) the minimum.

CC: @arch1t3cht (because you probably Have Opinions)