### PR TITLE
[autogen.sh] Add NOCONFIGURE

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,5 +2,7 @@
 mkdir -p src/config
 echo Running autoreconf...
 autoreconf -ivf
-echo Running configure...
-./configure "$@"
+if [ -z "$NOCONFIGURE" ]; then
+    echo Running configure...
+    ./configure "$@"
+fi


### PR DESCRIPTION
Don't force the user to run configure.

A lot of tool use this variable:
- https://github.com/adah1972/libunibreak/blob/master/autogen.sh#L12-L16
- https://github.com/fribidi/fribidi/blob/master/autogen.sh#L32-L35
- https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/autogen.sh?ref_type=heads#L120-126