### PR TITLE
[version.sh] Return success when version is found

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -7,7 +7,7 @@ strip_echo () {
 echo_maybe () {
     if test -n "$2"; then
         strip_echo "$1$2"
-        exit 1
+        exit 0
     fi
 }
 


### PR DESCRIPTION
Previously, echo_maybe() exited with code 1. This caused the script to signal an error even though version detection succeeded.

I just changed the exit code from 1 to 0 to indicate success when a version is found.