### PR TITLE
videosource: Prevent SeekTo() from targeting negative frame numbers

### DIFF
--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -908,11 +908,6 @@ bool FFMS_VideoSource::SeekTo(int n, int SeekOffset) {
 
     // The semantics here are basically "return true if we don't know exactly where our seek ended up (destination isn't frame 0)"
     if (SeekMode >= 0) {
-        int TargetFrame = n + SeekOffset;
-        if (TargetFrame < 0)
-            throw FFMS_Exception(FFMS_ERROR_SEEKING, FFMS_ERROR_UNKNOWN,
-                "Frame accurate seeking is not possible in this file");
-
         // Seeking too close to the end of the stream can result in a different decoder delay since
         // frames are returned as soon as draining starts, so avoid this to keep the delay predictable.
         // Is the +1 necessary here? Not sure, but let's keep it to be safe.
@@ -923,7 +918,7 @@ bool FFMS_VideoSource::SeekTo(int n, int SeekOffset) {
             // close to the end in open-gop files: https://trac.ffmpeg.org/ticket/10936
             EndOfStreamDist *= 2;
 
-        TargetFrame = std::min(TargetFrame, Frames.RealFrameNumber(std::max(0, VP.NumFrames - 1 - EndOfStreamDist)));
+        int TargetFrame = std::min(std::max(0, n + SeekOffset), Frames.RealFrameNumber(std::max(0, VP.NumFrames - 1 - EndOfStreamDist)));
 
         if (SeekMode < 3)
             TargetFrame = Frames.FindClosestVideoKeyFrame(TargetFrame);
@@ -997,7 +992,6 @@ FFMS_Frame *FFMS_VideoSource::GetFrame(int n) {
         // Is the seek destination time known? Does it belong to a frame?
         if (CurrentFrame < 0) {
             if (SeekMode == 1 || StartTime < 0) {
-                // No idea where we are so go back a bit further
                 SeekOffset -= 10;
                 Seek = true;
                 continue;


### PR DESCRIPTION
This prevents an exception from being thrown if the source's first frame is marked as skipped. The initial seek call ignores this, but https://github.com/FFMS/ffms2/commit/6467a17d70f5a2fc978b748a87c8ae2f08bc0a9c forces a reseek and calls `FFMS_Track::FrameFromPTS()` with `AllowHidden` set to false. This leads it to return -1, and `GetFrame()` then decreases `SeekOffset` to -10. When `SeekTo()` is called again, the offset points it to a negative frame number, and it throws the exception. By clamping `TargetFrame` in `SeekTo()` to [0, n + SeekOffset, <last frame>], subsequent seek calls can target the first frame or keyframe again and continue decoding normally.

(Can't replace `std::min()` and `std::max()` with `std::clamp()` because the CI runner doesn't support C++17 it seems.)