### PR TITLE
[ffms2.pc.in] Add -DFFMS_STATIC to Cflags.private

### DIFF
--- a/ffms2.pc.in
+++ b/ffms2.pc.in
@@ -12,3 +12,4 @@ Version: @FFMS_VERSION@
 Libs.private: @ZLIB_LDFLAGS@ -lz
 Libs: -L${libdir} -lffms2
 Cflags: -I${includedir}
+Cflags.private: -DFFMS_STATIC


### PR DESCRIPTION
This allow static consumers to automatically get the FFMS_STATIC flag needed for correct symbol handling. This affects only static linking, as intended.
Here is a bit more detail about Cflags.private: https://www.msys2.org/docs/pkgconfig/#cflagsprivate-static-libraries

Note that `Cflags.private` is only supported by pkgconf. The original pkg-config has an feature request about this: https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/38