### PR TITLE
Add FFMS_GetTrackMetadata

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE([1.11 subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])
 
-VERSION_INFO="5:1:1"
+VERSION_INFO="5:1:2"
 
 AC_MSG_CHECKING([if debug build is enabled])
 

--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -577,6 +577,15 @@ Returns the human-readable name ("long name" in FFmpeg terms) of the codec used 
 Useful if you want to, say, pop up a menu asking the user which tracks he or she wishes to index.
 Note that specifying an invalid track number may lead to undefined behavior.
 
+### FFMS_GetTrackMetadataI - gets the metadata of a given track
+
+[GetTrackMetadataI]: #ffms_gettrackmetadatai---gets-the-metadata-of-a-given-track
+```c++
+const char *FFMS_GetTrackMetadataI(FFMS_Indexer *Indexer, int Track, const char *Key);
+```
+Returns the value of the metadata entry associated with `Key` for the given track number in the media file represented by the given `FFMS_Indexer` object.
+For the list of commonly used metadata keys, see the `metadata_api Public Metadata API` comment in [avformat.h](https://code.ffmpeg.org/FFmpeg/FFmpeg/src/branch/master/libavformat/avformat.h).
+
 ### FFMS_GetFormatNameI - gets the name of the container format used in the given indexer
 
 [GetFormatNameI]: #ffms_getformatnamei---gets-the-name-of-the-container-format-used-in-the-given-indexer

--- a/doc/ffms2-changelog.md
+++ b/doc/ffms2-changelog.md
@@ -3,6 +3,7 @@
   - FFmpeg 7.1 is now the minimum requirement.
   - Added layered decoding support, for e.g. spatial MV-HEVC.
   - Added LastEndPTS to FFMS_VideoProperties. This field is the equivalent of LastEndTime, but it is expressed in the video timebase.
+  - Added FFMS_GetTrackMetadataI.
 
 - 5.0
   - Fixed all issues with FFmpeg 6.1 which is now the minimum requirement

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -462,6 +462,7 @@ FFMS_API(int) FFMS_GetTrackType(FFMS_Track *T);
 FFMS_API(int) FFMS_GetTrackTypeI(FFMS_Indexer *Indexer, int Track);
 FFMS_API(FFMS_IndexErrorHandling) FFMS_GetErrorHandling(FFMS_Index *Index);
 FFMS_API(const char *) FFMS_GetCodecNameI(FFMS_Indexer *Indexer, int Track);
+FFMS_API(const char *) FFMS_GetTrackMetadataI(FFMS_Indexer *Indexer, int Track, const char *Key);
 FFMS_API(const char *) FFMS_GetFormatNameI(FFMS_Indexer *Indexer);
 FFMS_API(int) FFMS_GetNumFrames(FFMS_Track *T);
 FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfo(FFMS_Track *T, int Frame);

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((5 << 24) | (1 << 16) | (1 << 8) | 0)
+#define FFMS_VERSION ((5 << 24) | (1 << 16) | (2 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>

--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -270,6 +270,10 @@ FFMS_API(const char *) FFMS_GetCodecNameI(FFMS_Indexer *Indexer, int Track) {
     return Indexer->GetTrackCodec(Track);
 }
 
+FFMS_API(const char *) FFMS_GetTrackMetadataI(FFMS_Indexer *Indexer, int Track, const char *Key) {
+    return Indexer->GetTrackMetadata(Track, Key);
+}
+
 FFMS_API(int) FFMS_GetNumFrames(FFMS_Track *T) {
     return T->VisibleFrameCount();
 }

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -431,6 +431,12 @@ const char *FFMS_Indexer::GetTrackCodec(int Track) {
     return codec ? codec->name : nullptr;
 }
 
+const char *FFMS_Indexer::GetTrackMetadata(int Track, const char *Key) {
+    AVStream *stream = FormatContext->streams[Track];
+    AVDictionaryEntry *Entry = av_dict_get(stream->metadata, Key, NULL, 0);
+    return Entry ? Entry->value : nullptr;
+}
+
 FFMS_Index *FFMS_Indexer::DoIndexing() {
     std::vector<SharedAVContext> AVContexts(FormatContext->nb_streams);
 

--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -100,6 +100,7 @@ public:
     int GetNumberOfTracks();
     FFMS_TrackType GetTrackType(int Track);
     const char *GetTrackCodec(int Track);
+    const char *GetTrackMetadata(int Track, const char *Key);
     const char *GetFormatName();
 };
 


### PR DESCRIPTION
Add FFMS_GetTrackMetadata.
This is useful for tool like Aegisub that expose all the audio tracks to the user by exposing the track title

<details>
<summary>
I tested this PR with this code
</summary>

```c++
#include <ffms.h>
#include <stdexcept>
#include <string>
#include <memory>
#include <iostream>


int main() {
    const std::string filename = "C:\\Users\\moi15moi\\Downloads\\Ranma 1-2 (2024) S02E04 Grabuge sur la plage (1).mkv";
    int index = 1;

    char errmsg[1024];
    FFMS_ErrorInfo errinfo;
    errinfo.Buffer      = errmsg;
    errinfo.BufferSize  = sizeof(errmsg);
    errinfo.ErrorType   = FFMS_ERROR_SUCCESS;
    errinfo.SubType     = FFMS_ERROR_SUCCESS;
    
    FFMS_Init(0, 0);

    FFMS_Indexer *indexer = FFMS_CreateIndexer(filename.c_str(), &errinfo);
    if (!indexer)
        throw std::runtime_error("ffms2 reported an error while calling FFMS_CreateIndexer: " + std::string(errinfo.Buffer) + ".");    

    int num_tracks = FFMS_GetNumTracksI(indexer);
    if (index >= num_tracks)
        throw std::invalid_argument("The index " + std::to_string(index) + " is not in the file " + filename + ".");    

    int track_type = FFMS_GetTrackTypeI(indexer, index);
    std::string steam_media_type = "";
    switch (track_type) {
        case FFMS_TYPE_VIDEO:
            steam_media_type = "video";
            break;
        case FFMS_TYPE_AUDIO:
            steam_media_type = "audio";
            break;
        case FFMS_TYPE_DATA:
            steam_media_type = "data";
            break;
        case FFMS_TYPE_SUBTITLE:
            steam_media_type = "subtitle";
            break;
        case FFMS_TYPE_ATTACHMENT:
            steam_media_type = "attachment";
            break;
        default:
            steam_media_type = "unknown";
            break;
    }
    std::cout << "The index  is a \"" + steam_media_type + "\" stream." << std::endl;  

    const char *language = FFMS_GetTrackMetadataI(indexer, index, "language");
    if (language)
    {
        std::cout << "Language: " << std::string(language) << std::endl;
    }
    else 
    {
        std::cout << "Language: NULL" << std::endl;
    }

    const char *title = FFMS_GetTrackMetadataI(indexer, index, "title");
    if (title)
    {
        std::cout << "Title: " << std::string(title) << std::endl;
    }
    else 
    {
        std::cout << "Title: NULL" << std::endl;
    }

    const char *key_that_doesnt_exist = FFMS_GetTrackMetadataI(indexer, index, "key_that_doesnt_exist");
    if (key_that_doesnt_exist)
    {
        std::cout << "key_that_doesnt_exist: " << std::string(key_that_doesnt_exist) << std::endl;
    }
    else 
    {
        std::cout << "key_that_doesnt_exist: NULL" << std::endl;
    }


    return 0;
}
```
</details>

@arch1t3cht 