### PR TITLE
Fixes to the minimum distance to end of stream when seeking

### DIFF
--- a/src/core/videosource.cpp
+++ b/src/core/videosource.cpp
@@ -919,7 +919,7 @@ bool FFMS_VideoSource::SeekTo(int n, int SeekOffset) {
         // Seeking too close to the end of the stream can result in a different decoder delay since
         // frames are returned as soon as draining starts, so avoid this to keep the delay predictable.
         // Is the +1 necessary here? Not sure, but let's keep it to be safe.
-        int EndOfStreamDist = CodecContext->has_b_frames + 1;
+        int EndOfStreamDist = Delay.ReorderDelay + Delay.ThreadDelay + 1;
 
         TargetFrame = std::min(TargetFrame, Frames.RealFrameNumber(std::max(0, VP.NumFrames - 1 - EndOfStreamDist)));
 


### PR DESCRIPTION
Remove the now obsolete workaround for H264 and fix a bug that was hidden by that workaround.