### PR TITLE
Add FFMS_GetContainerFirstTimeI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE([1.11 subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])
 
-VERSION_INFO="5:1:1"
+VERSION_INFO="5:1:2"
 
 AC_MSG_CHECKING([if debug build is enabled])
 

--- a/doc/ffms2-api.md
+++ b/doc/ffms2-api.md
@@ -577,6 +577,16 @@ Returns the human-readable name ("long name" in FFmpeg terms) of the codec used 
 Useful if you want to, say, pop up a menu asking the user which tracks he or she wishes to index.
 Note that specifying an invalid track number may lead to undefined behavior.
 
+### FFMS_GetContainerFirstTimeI - gets the container first time
+
+[GetContainerFirstTimeI]: #ffms_getcontainerfirsttimei---gets-the-container-first-time
+```c++
+bool FFMS_GetContainerFirstTimeI(FFMS_Indexer *Indexer, int64_t *pts, int *timebase);
+```
+Returns the container start time of the media file represented by the given `FFMS_Indexer` object.
+On success, *pts* is set to the container start timestamps (which correspond to `AVFormatContext::start_time` in FFmpeg).
+Return true on success, otherwise, false.
+
 ### FFMS_GetFormatNameI - gets the name of the container format used in the given indexer
 
 [GetFormatNameI]: #ffms_getformatnamei---gets-the-name-of-the-container-format-used-in-the-given-indexer

--- a/doc/ffms2-changelog.md
+++ b/doc/ffms2-changelog.md
@@ -3,6 +3,7 @@
   - FFmpeg 7.1 is now the minimum requirement.
   - Added layered decoding support, for e.g. spatial MV-HEVC.
   - Added LastEndPTS to FFMS_VideoProperties. This field is the equivalent of LastEndTime, but it is expressed in the video timebase.
+  - Added FFMS_GetContainerFirstTimeI.
 
 - 5.0
   - Fixed all issues with FFmpeg 6.1 which is now the minimum requirement

--- a/include/ffms.h
+++ b/include/ffms.h
@@ -22,7 +22,7 @@
 #define FFMS_H
 
 // Version format: major - minor - micro - bump
-#define FFMS_VERSION ((5 << 24) | (1 << 16) | (1 << 8) | 0)
+#define FFMS_VERSION ((5 << 24) | (1 << 16) | (2 << 8) | 0)
 
 #include <stdint.h>
 #include <stddef.h>
@@ -462,6 +462,7 @@ FFMS_API(int) FFMS_GetTrackType(FFMS_Track *T);
 FFMS_API(int) FFMS_GetTrackTypeI(FFMS_Indexer *Indexer, int Track);
 FFMS_API(FFMS_IndexErrorHandling) FFMS_GetErrorHandling(FFMS_Index *Index);
 FFMS_API(const char *) FFMS_GetCodecNameI(FFMS_Indexer *Indexer, int Track);
+FFMS_API(bool) FFMS_GetContainerFirstTimeI(FFMS_Indexer *Indexer, int64_t *pts, int *timebase); /* Introduced in FFMS_VERSION ((5 << 24) | (1 << 16) | (2 << 8) | 0) */
 FFMS_API(const char *) FFMS_GetFormatNameI(FFMS_Indexer *Indexer);
 FFMS_API(int) FFMS_GetNumFrames(FFMS_Track *T);
 FFMS_API(const FFMS_FrameInfo *) FFMS_GetFrameInfo(FFMS_Track *T, int Frame);

--- a/src/core/ffms.cpp
+++ b/src/core/ffms.cpp
@@ -270,6 +270,10 @@ FFMS_API(const char *) FFMS_GetCodecNameI(FFMS_Indexer *Indexer, int Track) {
     return Indexer->GetTrackCodec(Track);
 }
 
+FFMS_API(bool) FFMS_GetContainerFirstTimeI(FFMS_Indexer *Indexer, int64_t *pts, int *timebase) {
+    return Indexer->GetFirstTime(pts, timebase);
+}
+
 FFMS_API(int) FFMS_GetNumFrames(FFMS_Track *T) {
     return T->VisibleFrameCount();
 }

--- a/src/core/indexing.cpp
+++ b/src/core/indexing.cpp
@@ -431,6 +431,19 @@ const char *FFMS_Indexer::GetTrackCodec(int Track) {
     return codec ? codec->name : nullptr;
 }
 
+bool FFMS_Indexer::GetFirstTime(int64_t *pts, int *timebase) {
+    if (FormatContext->start_time == AV_NOPTS_VALUE)
+        return false;
+
+    if (pts)
+        *pts = FormatContext->start_time;
+
+    if (timebase)
+        *timebase = AV_TIME_BASE;
+
+    return true;
+}
+
 FFMS_Index *FFMS_Indexer::DoIndexing() {
     std::vector<SharedAVContext> AVContexts(FormatContext->nb_streams);
 

--- a/src/core/indexing.h
+++ b/src/core/indexing.h
@@ -100,6 +100,7 @@ public:
     int GetNumberOfTracks();
     FFMS_TrackType GetTrackType(int Track);
     const char *GetTrackCodec(int Track);
+    bool GetFirstTime(int64_t *pts, int *timebase);
     const char *GetFormatName();
 };
 


### PR DESCRIPTION
This PR expose `AVFormatContext::start_time` to users.
This is usefull for tool like aegisub which want to emulate how mpv set the timestamps.
It allow to fix https://github.com/arch1t3cht/Aegisub/issues/172

@arch1t3cht 