### PR TITLE
Fix flag comparisons in FindPacket

### DIFF
--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -185,6 +185,11 @@ const std::array<std::vector<AVPacketProp>, 5> FindPacketCheckSequence = {{
 // If examples come up where this fallback sequence becomes relevant, it can
 // be adjusted.
 int FFMS_Track::FindPacket(const AVPacket &packet) const {
+    if (!packet.data && !packet.side_data_elems) {
+        // Empty packet signaling EOF
+        return -1;
+    }
+
     FrameInfo F;
     F.PTS = UseDTS ? packet.dts : packet.pts;
 

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -213,9 +213,9 @@ int FFMS_Track::FindPacket(const AVPacket &packet) const {
                         case AVPacketProp::Pos:
                             return it->FilePos == packet.pos;
                         case AVPacketProp::Hidden:
-                            return it->MarkedHidden == (packet.flags & AV_PKT_FLAG_DISCARD);
+                            return it->MarkedHidden == !!(packet.flags & AV_PKT_FLAG_DISCARD);
                         case AVPacketProp::Key:
-                            return it->KeyFrame == (packet.flags & AV_PKT_FLAG_KEY);
+                            return it->KeyFrame == !!(packet.flags & AV_PKT_FLAG_KEY);
                     }
                     return false;
                 });


### PR DESCRIPTION
This did not actually break any samples because even the PTS + Pos
combination was enough to uniquely identify all packets in the test
files, but before this commit the Hidden comparison was broken on
packets that had a Hidden flag set.

Either way, sorry for introducing this bug.